### PR TITLE
PlayerScore and SpreadSheetUpdate additions

### DIFF
--- a/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
@@ -161,6 +161,18 @@ function fromColor(color)
     return _colorToFaction[color]
 end
 
+--- Get faction from token name (strips off any "owner token" or "command token" suffix, if present)
+function fromTokenName(tokenName)
+    assert(type(tokenName) == 'string')
+    tokenName = string.match(tokenName, '^(.*) .* Token$') or tokenName
+    _maybeUpdate()
+    for color, faction in pairs(_colorToFaction) do
+        if faction.tokenName == tokenName then
+            return faction
+        end
+    end
+end
+
 function _maybeUpdate()
     if not _update.time or (Time.time - _update.time) > _update.periodicUpdateSeconds then
         _update.time = Time.time

--- a/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
@@ -161,18 +161,6 @@ function fromColor(color)
     return _colorToFaction[color]
 end
 
---- Get faction from token name (strips off any "owner token" or "command token" suffix, if present)
-function fromTokenName(tokenName)
-    assert(type(tokenName) == 'string')
-    tokenName = string.match(tokenName, '^(.*) .* Token$') or tokenName
-    _maybeUpdate()
-    for color, faction in pairs(_colorToFaction) do
-        if faction.tokenName == tokenName then
-            return faction
-        end
-    end
-end
-
 function _maybeUpdate()
     if not _update.time or (Time.time - _update.time) > _update.periodicUpdateSeconds then
         _update.time = Time.time

--- a/Objects/TI4_SpreadsheetUpdate.ttslua
+++ b/Objects/TI4_SpreadsheetUpdate.ttslua
@@ -18,7 +18,17 @@ local _data = {
     updateBetweenTurns = false,
     saveIds = false,
 
-    playerColorToTechs = false,
+    playerColorToTechs = {},
+    playerColorToStrategy = {},
+    playerScores = {},
+    stageOneObjectives = {},
+    StageOneMap = {},
+    stageTwoObjectives = {},
+    StageTwoMap = {},
+    playerSecrets = {},
+    supportMap = {},
+    MecatolPoints = {},
+    otherPoints = {}
 }
 
 function onLoad(saveState)
@@ -59,7 +69,7 @@ function onPlayerTurnStart(playerColorStart, playerColorPrevious)
     updateScoreState()
 
     -- Optionally also push to sheet.
-    if _data.updateBetweenTurns() then
+    if _data.updateBetweenTurns then
         updateSpreadsheetTech()
         updateSpreadsheetScore()
     end
@@ -67,7 +77,7 @@ end
 
 function onDrop(player_color)
 
-    local nameToObjects = CrLua.TI4.PlayerScore._getNameToObjects()
+    --[[local nameToObjects = CrLua.TI4.PlayerScore._getNameToObjects()
     for k, v in pairs(nameToObjects) do
         print('xxx1 ' .. k)
     end
@@ -78,7 +88,7 @@ function onDrop(player_color)
     local colorToScore = CrLua.TI4.PlayerScore.colorToScore(targetToOwnerTokens)
     for k, v in pairs(colorToScore) do
         print('xxx3 ' .. k .. ' -> ' .. v)
-    end
+    end]]--
 
 end
 
@@ -87,22 +97,35 @@ end
 function updateTechState()
     -- Update the local table to preserve order.  Does not push to sheet.
     _data.playerColorToTechs = CrLua.TI4.PlayerTech.updateAllPlayersToTech(_data.playerColorToTechs)
+
 end
 
 function updateScoreState()
     local nameToScoreObjects = CrLua.TI4.PlayerScore.getNameToScoreObjects()
     local nameToOwnerTokens = CrLua.TI4.PlayerScore.nameToOwnerTokens(nameToScoreObjects)
-    local colorToScore = CrLua.TI4.PlayerScore.colorToScore(nameToScoreObjects, nameToOwnerTokens)
+    _data.playerScores = CrLua.TI4.PlayerScore.colorToScore(nameToScoreObjects, nameToOwnerTokens)
+    _data.stageOneObjectives = CrLua.TI4.PlayerScore.updatePublicOneObjectives(_data.stageOneObjectives, nameToScoreObjects)
+    _data.StageOneMap = CrLua.TI4.PlayerScore.mapStageOne(nameToOwnerTokens)
+    _data.stageTwoObjectives = CrLua.TI4.PlayerScore.updatePublicTwoObjectives(_data.stageTwoObjectives, nameToScoreObjects)
+    _data.StageTwoMap = CrLua.TI4.PlayerScore.mapStageTwo(nameToOwnerTokens)
+    _data.playerSecrets = CrLua.TI4.PlayerScore.updateSecrets(_data.playerSecrets, nameToOwnerTokens)
+    _data.playerColorToStrategy = CrLua.TI4.PlayerScore.updateStrategy()
+    _data.supportMap = CrLua.TI4.PlayerScore.mapSupports(nameToOwnerTokens)
+    _data.MecatolPoints = CrLua.TI4.PlayerScore.getMecatolPoints(_data.MecatolPoints, nameToOwnerTokens)
+    _data.otherPoints = CrLua.TI4.PlayerScore.mapOtherPoints(_data.otherPoints, nameToOwnerTokens)
 
-    for k, v in pairs(nameToScoreObjects) do
+    --[[for k, v in pairs(nameToScoreObjects) do
         print('nameToScoreObjects #' .. k .. ' ' .. #v)
     end
     for k, v in pairs(nameToOwnerTokens) do
         print('nameToOwnerTokens #' .. k .. ' ' .. #v)
-    end
-    for k, v in pairs(colorToScore) do
-        print('colorToScore ' .. k .. ' ' .. v)
-    end
+        for i, j in ipairs(v) do
+          print(v[i].getName())
+        end
+    end]]--
+    -- for k, v in pairs(colorToScore) do
+    --    print('colorToScore ' .. k .. ' ' .. v)
+    --end
 end
 
 -------------------------------------------------------------------------------
@@ -140,6 +163,14 @@ end
 function updateSpreadsheetScore()
     local sheetId = _sheetId(_data.sheetIdScore)
     local sheetName = _data.sheetNameScore
+    local cells = CrLua.TI4.PlayerScore.getCells(_data.stageOneObjectives, _data.stageTwoObjectives, _data.playerScores, _data.playerSecrets, _data.playerColorToStrategy, _data.StageOneMap, _data.StageTwoMap, _data.supportMap, _data.MecatolPoints, _data.otherPoints)
+
+    if sheetId then
+        CrLua.Log.i(TAG, 'updating score spreadsheet')
+        CrLua.TTS.Spreadsheet.update(sheetId, sheetName, cells)
+    else
+        CrLua.Log.i(TAG, 'no score spreadsheet, not updating score')
+    end
 end
 -------------------------------------------------------------------------------
 

--- a/TI4/PlayerScore.ttslua
+++ b/TI4/PlayerScore.ttslua
@@ -7,7 +7,7 @@ CrLua = CrLua or {}  -- global, <include> wraps in a do .. end block
 CrLua.TI4 = CrLua.TI4 or {}
 CrLua.TI4.PlayerScore = assert(not CrLua.TI4.PlayerScore) and {
     _require = { 'List', 'TTS.HelperClient', 'TTS.Overlap' },
-    _allowMissingKeys = {}
+    _allowMissingKeys = {'PHASE1', 'PHASE2', 'SECRET', 'STRATEGY', 'AGENDA', 'ACTIONS'}
 }
 
 CrLua.TI4.PlayerScore.PHASE1 = {
@@ -79,10 +79,57 @@ CrLua.TI4.PlayerScore.STRATEGY = {
     ['Imperial'] = 'Imperial',
 }
 
+CrLua.TI4.PlayerScore.SUPPORTS = {
+    ['Support for the Throne (Blue)'] = 'SUPPORT for the THRONE',
+    ['Support for the Throne (Purple)'] = 'SUPPORT for the THRONE',
+    ['Support for the Throne (Yellow)'] = 'SUPPORT for the THRONE',
+    ['Support for the Throne (Red)'] = 'SUPPORT for the THRONE',
+    ['Support for the Throne (Green)'] = 'SUPPORT for the THRONE',
+    ['Support for the Throne (White)'] = 'SUPPORT for the THRONE'
+}
+
+CrLua.TI4.PlayerScore.ACTIONS = {
+    ['Imperial Rider'] = 'IMPERIAL RIDER'
+}
+
+CrLua.TI4.PlayerScore.factionNicknames = {
+    ['The Arborec'] = 'Arborec',
+    ['The Barony Of Letnev'] = 'Letnev',
+    ['The Clan Of Saar'] = 'Saar',
+    ['The Embers Of Muaat'] = 'Muaat',
+    ['The Emirates Of Hacan'] = 'Hacan',
+    ['The Federation Of Sol'] = 'Sol',
+    ['The Ghosts Of Creuss'] = 'Creuss',
+    ['The L1Z1X Mindnet'] = 'L1Z1X',
+    ['The Mentak Coalition'] = 'Mentak',
+    ['The Naalu Collective'] = 'Naalu',
+    ['The Nekro Virus'] = 'Nekro',
+    ["The Sardakk N'orr"] = "N'orr",
+    ['The Universities of Jol-Nar'] = 'Jol-Nar',
+    ['The Winnu'] = 'Winnu',
+    ['The Xxcha Kingdom'] = 'Xxcha',
+    ['The Yin Brotherhood'] = 'Yin',
+    ['The Yssaril Tribes'] = 'Yssaril',
+}
+
+CrLua.TI4.PlayerScore.colorAbbreviation = {
+    ['Blue'] = 'B',
+    ['Purple'] = 'P',
+    ['Yellow'] = 'Y',
+    ['Red'] = 'R',
+    ['Green'] = 'G',
+    ['White'] = 'W',
+    --['Orange'] = 'O',
+    --['Pink'] = 'Pn',
+}
+
 CrLua.TI4.PlayerScore.MECATOL = 'Custodians'
 CrLua.TI4.PlayerScore.SCOREBOARD = 'Scoreboard'
 
 local _factionHelper = CrLua.TTS.HelperClient.get('TI4_FACTION_HELPER')
+local _zoneHelper = CrLua.TTS.HelperClient.get('TI4_ZONE_HELPER')
+
+
 
 --- Get map from scoring relevant object name to lists of objects with name.
 function CrLua.TI4.PlayerScore.getNameToScoreObjects()
@@ -92,6 +139,8 @@ function CrLua.TI4.PlayerScore.getNameToScoreObjects()
         CrLua.TI4.PlayerScore.SECRET,
         CrLua.TI4.PlayerScore.AGENDA,
         CrLua.TI4.PlayerScore.STRATEGY,
+        CrLua.TI4.PlayerScore.SUPPORTS,
+        CrLua.TI4.PlayerScore.ACTIONS,
         { [CrLua.TI4.PlayerScore.MECATOL] = true },
         { [CrLua.TI4.PlayerScore.SCOREBOARD] = true },
     }
@@ -109,9 +158,11 @@ function CrLua.TI4.PlayerScore.getNameToScoreObjects()
     end
 
     for _, object in ipairs(getAllObjects()) do
-        local objects = nameToScoreObjects[object.getName()]
-        if objects then
-            table.insert(objects, object)
+        if object.tag ~= 'Card' or object.is_face_down == false then
+            local objects = nameToScoreObjects[object.getName()]
+            if objects then
+                table.insert(objects, object)
+            end
         end
     end
 
@@ -155,7 +206,7 @@ function CrLua.TI4.PlayerScore.score(scoreboard, ownerToken)
 
     -- Scoreboard local space x.
     local p = scoreboard.positionToLocal(center)
-    print ('xxx ' .. ownerToken.getName() .. ' x=' .. p.x .. ' z=' .. p.z)
+    -- print ('xxx ' .. ownerToken.getName() .. ' x=' .. p.x .. ' z=' .. p.z)
     local u = -(p.x - 3.25) / 6.5
     return u * (scoreboard.is_face_down and 15 or 11)
 end
@@ -177,8 +228,410 @@ function CrLua.TI4.PlayerScore.colorToScore(nameToScoreObjects, nameToOwnerToken
         local color = ownerTokenNameToColor[ownerToken.getName()]
         assert(color)
         local score = CrLua.TI4.PlayerScore.score(scoreboard, ownerToken)
-        colorToScore[color] = math.max(colorToScore[color] or 0, score)
+        colorToScore[color] = math.floor(math.max(colorToScore[color] or 0, score))
+    end
+    return colorToScore
+end
+
+--- Generate the entire spreadsheet contents.
+function CrLua.TI4.PlayerScore.getCells(PHASE1objectives, PHASE2objectives, colorToScore, playerSecrets, colorToStrategy, stageOneMap, stageTwoMap, supportMap, MecatolPoints, otherPoints)
+    local cells = {}
+    local colorToCellName = {
+        ['Blue'] = 'B3',
+        ['Purple'] = 'B4',
+        ['Yellow'] = 'B5',
+        ['Red'] = 'O3',
+        ['Green'] = 'O4',
+        ['White'] = 'O5',
+        --['Orange'] = 'H',
+        --['Pink'] = 'I',
+    }
+    local colorToCellFaction = {
+        ['Blue'] = 'F3',
+        ['Purple'] = 'F4',
+        ['Yellow'] = 'F5',
+        ['Red'] = 'S3',
+        ['Green'] = 'S4',
+        ['White'] = 'S5',
+        --['Orange'] = 'H',
+        --['Pink'] = 'I',
+    }
+    local colorToCellScore = {
+        ['Blue'] = 'J3',
+        ['Purple'] = 'J4',
+        ['Yellow'] = 'J5',
+        ['Red'] = 'W3',
+        ['Green'] = 'W4',
+        ['White'] = 'W5',
+        --['Orange'] = 'H',
+        --['Pink'] = 'I',
+    }
+    local colorToCellStrategy = {
+        ['Blue'] = 'K3',
+        ['Purple'] = 'K4',
+        ['Yellow'] = 'K5',
+        ['Red'] = 'X3',
+        ['Green'] = 'X4',
+        ['White'] = 'X5',
+        --['Orange'] = 'H',
+        --['Pink'] = 'I',
+    }
+    local stageOneCells = {
+        'B7', 'B8', 'B9', 'B10', 'B11', 'B18',
+    }
+    local stageTwoCells = {
+        'B12', 'B13', 'B14', 'B15', 'B16', 'B19',
+    }
+    local secretsCells = {
+        {'N7','S7'},
+        {'N8', 'S8'},
+        {'N9', 'S9'},
+        {'N10', 'S10'},
+        {'N11', 'S11'},
+        {'N12', 'S12'},
+        {'N13', 'S13'},
+        {'N14', 'S14'},
+        {'N15', 'S15'},
+        {'T7', 'Y7'},
+        {'T8', 'Y8'},
+        {'T9', 'Y9'},
+        {'T10', 'Y10'},
+        {'T11', 'Y11'},
+        {'T12', 'Y12'},
+        {'T13', 'Y13'},
+        {'T14', 'Y14'},
+        {'T15', 'Y15'},
+        }
+
+    local PublicCompletionCells = {
+        ['Blue'] = 'G',
+        ['Purple'] = 'H',
+        ['Yellow'] = 'I',
+        ['Red'] = 'J',
+        ['Green'] = 'K',
+        ['White'] = 'L',
+        --['Orange'] = '',
+        --['Pink'] = 'I',
+        ['PHASE1row'] = {'7', '8', '9', '10', '11', '18'},
+        ['PHASE2row'] = {'12', '13', '14', '15', '16', '19'}
+    }
+
+    local SupportCells = {
+        ['Blue'] = 'S21',
+        ['Purple'] = 'Y20',
+        ['Yellow'] = 'Y22',
+        ['Red'] = 'Y21',
+        ['Green'] = 'S22',
+        ['White'] = 'S20',
+        --['Orange'] = 'H',
+        --['Pink'] = 'I',
+    }
+
+    local OtherPointCells = {
+        ['Imperial Rider'] = 'S24',
+        ['single'] = {
+            {'N25', 'S25'},
+            {'T24', 'Y24'},
+            {'T25', 'Y25'}
+        },
+        ['multi'] = {
+            ['Column'] = 'N',
+            ['Rows'] = {'26', '27'},
+            ['Blue'] = 'S',
+            ['Purple'] = 'T',
+            ['Yellow'] = 'U',
+            ['Red'] = 'V',
+            ['Green'] = 'W',
+            ['White'] = 'X',
+        }
+    }
+
+    local MecatolCells = {'S23', 'T23', 'U23', 'V23', 'W23', 'X23', 'Y23'}
+
+    for _, player in ipairs(Player.getPlayers()) do
+        local nameCell = colorToCellName[player.color]
+        local factionCell = colorToCellFaction[player.color]
+        local scoreCell = colorToCellScore[player.color]
+        local strategyCell = colorToCellStrategy[player.color]
+
+        local faction = _factionHelper.fromColor(player.color)
+        local factionNickname = false
+        if faction then factionNickname = CrLua.TI4.PlayerScore.factionNicknames[faction.name] end
+
+        cells[nameCell] = player.steam_name
+        cells[factionCell] = factionNickname
+        cells[scoreCell] = colorToScore[player.color]
+        cells[strategyCell] = CrLua.TI4.PlayerScore.STRATEGY[colorToStrategy[player.color]]
+
     end
 
-    return colorToScore
+    for _, val in ipairs(PHASE1objectives) do
+        cells[stageOneCells[_]] = CrLua.TI4.PlayerScore.PHASE1[val]
+        local completed = stageOneMap[val]
+        if completed then
+            for x, color in ipairs(completed) do
+                cells[PublicCompletionCells[color] .. PublicCompletionCells.PHASE1row[_]] = CrLua.TI4.PlayerScore.colorAbbreviation[color]
+            end
+        end
+    end
+
+    for _, val in ipairs(PHASE2objectives) do
+        cells[stageTwoCells[_]] = CrLua.TI4.PlayerScore.PHASE2[val]
+        local completed = stageTwoMap[val]
+        if completed then
+            for x, color in ipairs(completed) do
+                cells[PublicCompletionCells[color] .. PublicCompletionCells.PHASE2row[_]] = CrLua.TI4.PlayerScore.colorAbbreviation[color]
+            end
+        end
+    end
+
+    local objNum = 0
+    for playerColor, objectives in pairs(playerSecrets) do
+        for i, objective in ipairs(objectives) do
+            objNum = objNum + 1
+            cells[secretsCells[objNum][1]] = CrLua.TI4.PlayerScore.SECRET[objective]
+            cells[secretsCells[objNum][2]] = CrLua.TI4.PlayerScore.colorAbbreviation[playerColor]
+        end
+    end
+
+    for owner, target in pairs(supportMap) do
+        cells[SupportCells[owner]] = CrLua.TI4.PlayerScore.colorAbbreviation[target]
+    end
+
+    for i, color in ipairs(MecatolPoints) do
+        cells[MecatolCells[i]] = CrLua.TI4.PlayerScore.colorAbbreviation[color]
+    end
+
+    local singlePointCount = 0
+    local multiPointCount = 0
+    for key, map in pairs(otherPoints) do
+        if key == 'Shard of the Throne' or key == 'The Crown of Emphidia' or key == 'Holy Planet of Ixth' then
+            singlePointCount = singlePointCount + 1
+            if #map ~= 0 then
+                cells[OtherPointCells.single[singlePointCount][1]] = CrLua.TI4.PlayerScore.AGENDA[key]
+                cells[OtherPointCells.single[singlePointCount][2]] = CrLua.TI4.PlayerScore.colorAbbreviation[map[1]]
+            end
+        elseif key == 'Imperial Rider' then
+            if map ~= {} then cells[OtherPointCells[key]] = CrLua.TI4.PlayerScore.colorAbbreviation[map[1]] end
+        else
+            multiPointCount = multiPointCount + 1
+            cells[OtherPointCells['multi']['Column'] .. OtherPointCells['multi']['Rows'][multiPointCount]] = CrLua.TI4.PlayerScore.AGENDA[key]
+            for _, color in ipairs(map) do
+                cells[OtherPointCells['multi'][color] .. OtherPointCells['multi']['Rows'][multiPointCount]] = CrLua.TI4.PlayerScore.colorAbbreviation[color]
+            end
+        end
+    end
+
+    return cells
+
+end
+
+function CrLua.TI4.PlayerScore.updatePublicOneObjectives(PHASE1objectives, nameToScoreObjects)
+    assert(type(PHASE1objectives) == 'table')
+
+    local stageOne = {}
+
+    for key, map in pairs(nameToScoreObjects) do
+        local objective = CrLua.TI4.PlayerScore.PHASE1[key]
+        if objective then table.insert(stageOne, key) end
+    end
+
+
+    local oldPHASE1 = PHASE1objectives or {}
+    local newPHASE1 = stageOne or {}
+    local updatedPHASE1 = CrLua.List.pruneAndAppendMissing(oldPHASE1, newPHASE1) or {}
+
+    return updatedPHASE1
+end
+
+function CrLua.TI4.PlayerScore.updatePublicTwoObjectives(PHASE2objectives, nameToScoreObjects)
+    assert(type(PHASE2objectives) == 'table')
+
+    local stageTwo = {}
+
+    for key, map in pairs(nameToScoreObjects) do
+        local objective = CrLua.TI4.PlayerScore.PHASE2[key]
+        if objective then table.insert(stageTwo, key) end
+    end
+
+
+    local oldPHASE2 = PHASE2objectives or {}
+    local newPHASE2 = stageTwo or {}
+    local updatedPHASE2 = CrLua.List.pruneAndAppendMissing(oldPHASE2, newPHASE2) or {}
+
+    return updatedPHASE2
+end
+
+function CrLua.TI4.PlayerScore.updateSecrets(playerSecrets,nameToOwnerTokens)
+
+    assert(type(playerSecrets) == 'table')
+
+    local colorToSecrets = {
+        ['Blue'] ={},
+        ['Purple'] = {},
+        ['Yellow'] = {},
+        ['Red'] = {},
+        ['Green'] = {},
+        ['White'] = {},
+        --['Orange'] = {},
+        --['Pink'] = {},
+    }
+
+    for key, map in pairs(nameToOwnerTokens) do
+        if CrLua.TI4.PlayerScore.SECRET[key] then
+            if #map == 1 then
+                local ownerToken = map[1].getName()
+                local faction = _factionHelper.fromTokenName(ownerToken)
+                local playerColor = faction.color
+                table.insert(colorToSecrets[playerColor], key)
+            end
+        end
+    end
+
+    local updated = {
+        ['Blue'] ={},
+        ['Purple'] = {},
+        ['Yellow'] = {},
+        ['Red'] = {},
+        ['Green'] = {},
+        ['White'] = {},
+        --['Orange'] = {},
+        --['Pink'] = {},
+    }
+    for color, _ in pairs(_factionHelper.allFactions()) do
+        local oldSecrets = playerSecrets[color] or {}
+        local newSecrets = colorToSecrets[color] or {}
+        local updatedSecrets = CrLua.List.pruneAndAppendMissing(oldSecrets, newSecrets)
+        updated[color] = updatedSecrets
+    end
+
+    return updated
+end
+
+function CrLua.TI4.PlayerScore.mapStageOne(nameToOwnerTokens)
+
+    local stageOneMap = {}
+    for key, map in pairs(nameToOwnerTokens) do
+        if CrLua.TI4.PlayerScore.PHASE1[key] then
+            local tokenMap = {}
+            for i, token in ipairs(map) do
+                local ownerToken = map[i].getName()
+                local faction = _factionHelper.fromTokenName(ownerToken)
+                local playerColor = faction.color
+                table.insert(tokenMap, playerColor)
+            end
+            stageOneMap[key] = tokenMap
+        end
+    end
+
+    return stageOneMap
+end
+
+function CrLua.TI4.PlayerScore.mapStageTwo(nameToOwnerTokens)
+
+    local stageTwoMap = {}
+    for key, map in pairs(nameToOwnerTokens) do
+        if CrLua.TI4.PlayerScore.PHASE2[key] then
+            local tokenMap = {}
+            for i, token in ipairs(map) do
+                local ownerToken = map[i].getName()
+                local faction = _factionHelper.fromTokenName(ownerToken)
+                local playerColor = faction.color
+                table.insert(tokenMap, playerColor)
+            end
+            stageTwoMap[key] = tokenMap
+        end
+    end
+
+    return stageTwoMap
+end
+
+function CrLua.TI4.PlayerScore.updateStrategy()
+
+    local guidToName = {}
+    local guidToPosition = {}
+    for _, object in ipairs(getAllObjects()) do
+        local name = object.getName()
+        if CrLua.TI4.PlayerScore.STRATEGY[name] then
+            local guid = object.getGUID()
+            guidToName[guid] = name
+            guidToPosition[guid] = object.getPosition()
+        end
+    end
+
+    local guidToZone = _zoneHelper.zonesFromPositions(guidToPosition)
+    local colorToStrategy = {}
+
+    for guid, color in pairs(guidToZone) do
+        local strategy = assert(guidToName[guid])
+        if strategy then colorToStrategy[color] = strategy end
+    end
+
+    return colorToStrategy
+end
+
+function CrLua.TI4.PlayerScore.mapSupports(nameToOwnerTokens)
+    local supportMap = {}
+    for key, map in pairs(nameToOwnerTokens) do
+        local color = string.match(key, '^Support for the Throne %((%a+)%)$')
+        if color then
+            local ownerToken = map[1].getName()
+            local faction = _factionHelper.fromTokenName(ownerToken)
+            local playerColor = faction.color
+            supportMap[color] = playerColor
+        end
+    end
+
+    return supportMap
+end
+
+function CrLua.TI4.PlayerScore.getMecatolPoints(currentMecatolPoints, nameToOwnerTokens)
+    assert(type(currentMecatolPoints) == 'table')
+
+    local MecatolPoints = {}
+
+    for key, map in pairs(nameToOwnerTokens) do
+        if key == CrLua.TI4.PlayerScore.MECATOL then
+            for i, token in ipairs(map) do
+                local ownerToken = map[i].getName()
+                local faction = _factionHelper.fromTokenName(ownerToken)
+                local playerColor = faction.color
+                table.insert(MecatolPoints, playerColor)
+            end
+        end
+    end
+
+    local oldPoints = currentMecatolPoints or {}
+    local newPoints = MecatolPoints or {}
+    local updatedPoints = CrLua.List.pruneAndAppendMissing(oldPoints, newPoints) or {}
+    
+    return updatedPoints
+end
+
+function CrLua.TI4.PlayerScore.mapOtherPoints(currentOtherPoints, nameToOwnerTokens)
+    assert(type(currentOtherPoints) == 'table')
+
+    local otherPoints = {
+    }
+
+    for key, map in pairs(nameToOwnerTokens) do
+        if CrLua.TI4.PlayerScore.AGENDA[key] or CrLua.TI4.PlayerScore.ACTIONS[key] then
+            if #map ~= 0 then otherPoints[key] = {} end
+            for i, token in ipairs(map) do
+                local ownerToken = map[i].getName()
+                local faction = _factionHelper.fromTokenName(ownerToken)
+                local playerColor = faction.color
+                table.insert(otherPoints[key], playerColor)
+            end
+        end
+    end
+
+    local updatedPoints = {}
+    for key, pointList in pairs(otherPoints) do
+        local oldList = currentOtherPoints[key] or {}
+        local newList = otherPoints[key] or {}
+        local updatedList = CrLua.List.pruneAndAppendMissing(oldList, newList)
+        updatedPoints[key] = updatedList
+    end
+    return updatedPoints
 end


### PR DESCRIPTION
Included various updates to PlayerScore and SpreadSheetUpdate to gather relevant score information to update the external spreadsheet.

Mecatol points aren't working and require an update to CrLua.List pruneAndAppendMissing() to allow for duplicate values (e.g. {"Red", "Red"}.