### PR TITLE
Update Strategy Helper and PlayerTech

### DIFF
--- a/Objects/TI4_Helpers/TI4_StrategyCardHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_StrategyCardHelper.ttslua
@@ -498,8 +498,10 @@ function _getAllocateCommandTokensCount(playerColor, faction, lowerNameToInZoneC
         _safeBroadcastToColor('Cybernetic Enhancements Ω used. Returning to L1Z1X Mindnet player.', playerColor, {0.1,0.5,0.1})
         result = result + 1
         local mindnetColor = _factionHelper.fromTokenName('L1Z1X Mindnet').color
-        lowerNameToInZoneCards['cybernetic enhancements ω'][1].deal(1, mindnetColor)
-        _safeBroadcastToColor('Cybernetic Enhancements Ω used. Returned to your hand.', mindnetColor, {0.1,0.5,0.1})
+        if mindnetColor then
+            lowerNameToInZoneCards['cybernetic enhancements ω'][1].deal(1, mindnetColor)
+            _safeBroadcastToColor('Cybernetic Enhancements Ω used. Returned to your hand.', mindnetColor, {0.1,0.5,0.1})
+        end
     end
     return result
 end

--- a/TI4/PlayerTech.ttslua
+++ b/TI4/PlayerTech.ttslua
@@ -75,6 +75,8 @@ CrLua.TI4.PlayerTech.TECHNOLOGIES = {
     ['X-89 Bacterial Weapon Ω'] = 'X-89 B.W.',
     ['X-89 Bacterial Weapon'] = 'X-89 B.W.',
     ['Yin Spinner'] = 'Yin Spin',
+    ['????_REDACTED_????'] = 'Scenario Destroyer',
+    ['???_EXCEPTION_NO_ID_???'] = 'Scenario Tech'
 }
 
 local _factionHelper = CrLua.TTS.HelperClient.get('TI4_FACTION_HELPER')
@@ -112,10 +114,23 @@ function CrLua.TI4.PlayerTech.updateAllPlayersToTech(playerColorToTechs)
         table.insert(entry, tech)
     end
 
+    local prunedColorToTechs = {}
+    for color, techList in pairs(colorToTechs) do
+        local hash = {}
+        local prunedTechList = {}
+        for _, tech in ipairs(techList) do
+            if (not hash[tech]) then
+                prunedTechList[#prunedTechList+1] = tech
+                hash[tech] = true 
+            end
+        end
+        prunedColorToTechs[color] = prunedTechList
+    end
+
     local updated = {}
     for color, _ in pairs(_factionHelper.allFactions()) do
         local oldTechs = playerColorToTechs[color] or {}
-        local newTechs = colorToTechs[color] or {}
+        local newTechs = prunedColorToTechs[color] or {}
         local updatedTechs = CrLua.List.pruneAndAppendMissing(oldTechs, newTechs)
         updated[color] = updatedTechs
     end


### PR DESCRIPTION
Strategy Helper:
Ensures there's an L1Z1X player color before dealing their promissory note to hand.

Player Tech:
Removes duplicate techs, adds scenario tech support.