### PR TITLE
Swap plus and minus buttons

### DIFF
--- a/Objects/TI4_MultiRoller_Plat.ttslua
+++ b/Objects/TI4_MultiRoller_Plat.ttslua
@@ -494,8 +494,8 @@ function generateUnitXmlTable(unit_id, unit_stats, color)
                                     active = "false",
                                     onClick = "changeUnitCountXml(-1)",
                                     class = "changeCount",
-                                    offsetXY = "1600 200",
-                                    rectAlignment = "LowerRight",
+                                    offsetXY = "0 200",
+                                    rectAlignment = "LowerLeft",
                                     showAnimation = "FadeIn",
                                     hideAnimation = "FadeOut"
                                 }
@@ -508,8 +508,8 @@ function generateUnitXmlTable(unit_id, unit_stats, color)
                                     active = "false",
                                     onClick = "changeUnitCountXml(1)",
                                     class = "changeCount",
-                                    offsetXY = "-1600 200",
-                                    rectAlignment = "LowerLeft",
+                                    offsetXY = "0 200",
+                                    rectAlignment = "LowerRight",
                                     showAnimation = "FadeIn",
                                     hideAnimation = "FadeOut"
                                 }

--- a/Objects/TI4_MultiRoller_Plat.ttslua
+++ b/Objects/TI4_MultiRoller_Plat.ttslua
@@ -494,7 +494,7 @@ function generateUnitXmlTable(unit_id, unit_stats, color)
                                     active = "false",
                                     onClick = "changeUnitCountXml(-1)",
                                     class = "changeCount",
-                                    offsetXY = "-1600 200",
+                                    offsetXY = "1600 200",
                                     rectAlignment = "LowerRight",
                                     showAnimation = "FadeIn",
                                     hideAnimation = "FadeOut"
@@ -508,7 +508,7 @@ function generateUnitXmlTable(unit_id, unit_stats, color)
                                     active = "false",
                                     onClick = "changeUnitCountXml(1)",
                                     class = "changeCount",
-                                    offsetXY = "1600 200",
+                                    offsetXY = "-1600 200",
                                     rectAlignment = "LowerLeft",
                                     showAnimation = "FadeIn",
                                     hideAnimation = "FadeOut"


### PR DESCRIPTION
Some players said they'd find it more intuitive if the unit count button locations were swapped - minus on the left, plus on the right. This PR swaps those buttons.