### PR TITLE
PoK Wormholes: Tokens + Mallice

### DIFF
--- a/Objects/TI4_Helpers/TI4_SystemHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_SystemHelper.ttslua
@@ -573,6 +573,10 @@ function wormholes(playerColor)
             guids = {},
             connected = { 'delta' }
         },
+        ['gamma'] = {
+            guids = {},
+            connected = { 'gamma' }
+        },
     }
 
     local function addGuid(wormhole, guid)
@@ -602,6 +606,7 @@ function wormholes(playerColor)
         ['Alpha Wormhole Token'] = { 'alpha' },
         ['Beta Wormhole Token'] = { 'beta' },
         ['Hil Colish'] = { 'delta' },
+        ['Gamma Wormhole Token'] = { 'gamma' },
     }
 
     for _, object in ipairs(getAllObjects()) do
@@ -621,6 +626,15 @@ function wormholes(playerColor)
                 for _, wormhole in ipairs(nonSystemWormholes) do
                     addGuid(wormhole, guid)
                 end
+            end
+
+            if name == 'Ion Storm Wormhole Token' then
+                local wormholeSide = 'alpha'
+                if object.is_face_down then
+                    wormholeSide = 'beta'
+                end
+
+                addGuid(wormholeSide, guid)
             end
 
             if name == 'Wormhole Reconstruction' and (not object.is_face_down) and (not _deckHelper.isDiscard(guid)) then

--- a/Objects/TI4_Helpers/TI4_SystemHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_SystemHelper.ttslua
@@ -301,7 +301,7 @@ local _systems = {
     ['c50660'] = { tile = 79, anomalies = { 'asteroid field' }, wormholes = { 'alpha' } },
     ['0d634a'] = { tile = 80, anomalies = { 'supernova' } },
     ['c64d41'] = { tile = 81, anomalies = { 'supernova' }, faction = 'muaat' },
-    ['e85105'] = { tile = 82, localY = 0.101, wormholes = { 'alpha', 'beta', 'gamma' }, planets = {
+    ['e85105'] = { tile = 82, localY = 0.101, faceUpWormholes = { 'gamma', 'alpha', 'beta' }, faceDownWormholes = { 'gamma' }, planets = {
         { name = 'Mallice', resources = 0, influence = 3, legendary = true, legendaryCard = 'Exterrix Headquarters', trait = 'cultural', position = { x = 0.35, z = 0.18 }, radius = 0.8 },
     }},
 
@@ -925,7 +925,7 @@ function _fillMissingSystemData(guid, system)
     if system.faceUpWormholes or system.faceDownWormholes then
         local systemObject = getObjectFromGUID(guid)
         if systemObject then
-            system.wormholes = system.is_face_down and system.faceDownWormholes or system.faceUpWormholes
+            system.wormholes = systemObject.is_face_down and system.faceDownWormholes or system.faceUpWormholes
         end
     end
 end


### PR DESCRIPTION
- Fix bug in faceup/facedown wormhole picker for system tiles
- Give Mallice faceup/facedown wormholes ("faceup" is all 3 wormholes)
- Check for the Ion Storm when filling missing system data ("faceup" is alpha) (name must be "Ion Storm Wormhole Token")