### PR TITLE
Build Area Tool: Amalgamation

### DIFF
--- a/Objects/TI4_BuildArea.ttslua
+++ b/Objects/TI4_BuildArea.ttslua
@@ -631,8 +631,8 @@ function getProduceConsumeResourcesAndCost(produceConsumeItems)
         local unitAttrs = _getUnitAttributes(unit.unitType)
         -- If amalgamation is present, find how many units whose cost should be ignored.
         local amalgamatedUnitsOfType = produceConsumeItems.amalgamation and produceConsumeItems.amalgamation[unit.unitType] or 0
-        
-        result.cost = result.cost + math.ceil((unit.count - amalgamatedUnitsOfType) * (unitAttrs.cost or 0))
+
+        result.cost = result.cost + math.ceil(math.max(unit.count - amalgamatedUnitsOfType, 0) * (unitAttrs.cost or 0))
         result.numUnits = result.numUnits + unit.count
     end
 

--- a/Objects/TI4_BuildArea.ttslua
+++ b/Objects/TI4_BuildArea.ttslua
@@ -63,7 +63,6 @@ local OBJECT_EFFECTS = {
 }
 
 local FACTION_EFFECTS = {
-    --faction abilities
     ['Amalgamation'] = {
         amalgamation = true,
         fillUnitColor = true,

--- a/Objects/TI4_BuildArea.ttslua
+++ b/Objects/TI4_BuildArea.ttslua
@@ -266,10 +266,12 @@ local function _warpToSystem(system)
         error('missing system guid ' .. system.guid)
     end
 
+    local zoneColor = _zoneHelper.zoneFromPosition(self.getPosition())
+
     local unitObjects = {}
     for _, unit in ipairs(_getUnitsInsideBuildArea()) do
         local unitObject = getObjectFromGUID(unit.guid)
-        if unitObject then
+        if (not unit.color or unit.color == zoneColor) and unitObject then
             table.insert(unitObjects, unitObject)
         end
     end
@@ -541,7 +543,7 @@ function getProduceConsumeItems()
     -- add faction abilities if available
     if playerColor then
         local playerFaction = _factionHelper.fromColor(playerColor)
-        
+
         if playerFaction then
             for _, factionAbility in ipairs(playerFaction.abilities) do
                 local abilityEffect = FACTION_EFFECTS[factionAbility]

--- a/Objects/TI4_BuildArea.ttslua
+++ b/Objects/TI4_BuildArea.ttslua
@@ -62,6 +62,14 @@ local OBJECT_EFFECTS = {
     },
 }
 
+local FACTION_EFFECTS = {
+    --faction abilities
+    ['Amalgamation'] = {
+        amalgamation = true,
+        fillUnitColor = true,
+    },
+}
+
 -------------------------------------------------------------------------------
 
 local _config = {
@@ -525,13 +533,41 @@ function getProduceConsumeItems()
         sarween = false,
         hegemonic = false,
         warmachine = false,
+        amalgamation = false,
     }
 
-    for _, unit in ipairs(_getUnitsInsideBuildArea()) do
-        if result.produceUnitNameToUnitWithCount[unit.unitType] then
-            unit.count = unit.count + result.produceUnitNameToUnitWithCount[unit.unitType].count
+    local unitsInBuildingArea = _getUnitsInsideBuildArea()
+
+    -- add faction abilities if available
+    if playerColor then
+        local playerFaction = _factionHelper.fromColor(playerColor)
+        
+        if playerFaction then
+            for _, factionAbility in ipairs(playerFaction.abilities) do
+                local abilityEffect = FACTION_EFFECTS[factionAbility]
+                if abilityEffect then
+                    result.amalgamation = result.amalgamation or abilityEffect.amalgamation and {}
+
+                    -- Faction abilities may require a color on tokens
+                    if abilityEffect.fillUnitColor then
+                        unitsInBuildingArea = _unitHelper.fillUnitColors(unitsInBuildingArea)
+                    end
+                end
+            end
         end
-        result.produceUnitNameToUnitWithCount[unit.unitType] = unit
+    end
+
+    for _, unit in ipairs(unitsInBuildingArea) do
+        -- Count unit for building player if we're lacking any color info, or if unit color matches player color
+        if not playerColor or not unit.color or unit.color == playerColor then
+            if result.produceUnitNameToUnitWithCount[unit.unitType] then
+                unit.count = unit.count + result.produceUnitNameToUnitWithCount[unit.unitType].count
+            end
+            result.produceUnitNameToUnitWithCount[unit.unitType] = unit
+        -- If unit color doesn't match and amalgamation is active, count towards free units for the unit type
+        elseif result.amalgamation and playerColor and unit.color ~= playerColor then
+            result.amalgamation[unit.unitType] = (result.amalgamation[unit.unitType] or 0) + 1
+        end
     end
 
     local function addItem(name)
@@ -593,7 +629,10 @@ function getProduceConsumeResourcesAndCost(produceConsumeItems)
 
     for unitType, unit in pairs(produceConsumeItems.produceUnitNameToUnitWithCount) do
         local unitAttrs = _getUnitAttributes(unit.unitType)
-        result.cost = result.cost + math.ceil(unit.count * (unitAttrs.cost or 0))
+        -- If amalgamation is present, find how many units whose cost should be ignored.
+        local amalgamatedUnitsOfType = produceConsumeItems.amalgamation and produceConsumeItems.amalgamation[unit.unitType] or 0
+        
+        result.cost = result.cost + math.ceil((unit.count - amalgamatedUnitsOfType) * (unitAttrs.cost or 0))
         result.numUnits = result.numUnits + unit.count
     end
 
@@ -729,7 +768,6 @@ function drawBoundingBox()
                 end
             end
         end
-
 
     end
 


### PR DESCRIPTION
Add Vuil'Raith ability to spend off-color ships when producing.
- Build Area Tool now detects faction abilities. Amalgamation is the only current one.
- If Amalgamation is found, fill out unit color data
- Only count on-color ships for resource/production costs
- If Amalgamation is found, reduce cost for each matching off-color ship that is found.


In screenshot, only Carrier and 2x Fighters are costing resources. The extra off-color Dreadnought and Destroyer don't add negative resource cost.
![image](https://user-images.githubusercontent.com/2775535/100048440-d091b180-2de2-11eb-93a7-5a54248a9d90.png)

Of course, non-Amalgamation factions work normally (although now only counting on-color pieces)
![image](https://user-images.githubusercontent.com/2775535/100048588-25352c80-2de3-11eb-9fd2-7554aba76271.png)
