### PR TITLE
Build Area Tool: Tech and Commanders

### DIFF
--- a/Objects/TI4_BuildArea.ttslua
+++ b/Objects/TI4_BuildArea.ttslua
@@ -38,6 +38,9 @@ local OBJECT_EFFECTS = {
         requireFaceUp = true,
         hegemonic = true,
     },
+    ['AI Development Algorithm'] = {
+        aiDevelopmentAlgorithm = true
+    },
 
     -- Actions
     ['War Machine (1)'] = {
@@ -59,6 +62,13 @@ local OBJECT_EFFECTS = {
         anywhereInPlayerZone = true,
         requireFaceUp = true,
         warmachine = true,
+    },
+}
+
+local FACTION_EFFECTS = {
+    --faction abilities
+    ['Amalgamation'] = {
+        amalgamation = true,
     },
 }
 
@@ -490,8 +500,30 @@ function getProduceConsumeItems()
     CrLua.Log.d(TAG, 'getProduceConsumeItems')
     local playerColor = _data.playerColor
 
-    -- Get objects to consider.
     local inHandGuidSet = _zoneHelper.inHand()
+
+    -- Detect unit upgrades (AI Development Algorithm) and Alliance promissory notes
+
+    local playerAlliancePromissoryNotes = {}
+    local unitUpgrades = {}
+    for _, object in ipairs(getAllObjects()) do
+        if not inHandGuidSet[object.getGUID()] and not object.is_face_down and object.tag == 'Card'
+            and playerColor and _zoneHelper.zoneFromPosition(object.getPosition()) == playerColor then
+            local objectName = object.getName()
+
+            local colorMatch = string.match(objectName, '^Alliance %((%a+)%)$')
+            if colorMatch and colorMatch ~= playerColor then
+                playerAlliancePromissoryNotes[colorMatch] = true
+            end
+
+            if _unitHelper.isUnitUpgradeName(objectName) then
+                table.insert(unitUpgrades, objectName)
+            end
+        end
+    end
+
+    -- Get objects to consider.
+    
     local objects = CrLua.Table.join(_data.inside, {})
     local function useOutsizeBuildAreaObject(object)
         local objectEffects = OBJECT_EFFECTS[object.getName()]
@@ -508,7 +540,10 @@ function getProduceConsumeItems()
             return false
         end
         if objectEffects.anywhereInPlayerZone then
-            return playerColor and _zoneHelper.zoneFromPosition(object.getPosition()) == playerColor
+            local zoneColor = _zoneHelper.zoneFromPosition(object.getPosition())
+            local fromPlayer = playerColor and zoneColor == playerColor
+            local fromAlliance = objectEffects.viaAlliance and playerAlliancePromissoryNotes[zoneColor]
+            return fromPlayer or fromAlliance
         end
         return objectEffects.anywhereOnTable
     end
@@ -522,16 +557,53 @@ function getProduceConsumeItems()
         consumeObjectNameToCount = {},
         produceUnitNameToUnitWithCount = {},
         objectEffectsOverrides = {},
+        unitOverrides = {},
         sarween = false,
         hegemonic = false,
         warmachine = false,
+        aiDevelopmentAlgorithm = false,
+        amalgamation = false,
     }
 
-    for _, unit in ipairs(_getUnitsInsideBuildArea()) do
-        if result.produceUnitNameToUnitWithCount[unit.unitType] then
-            unit.count = unit.count + result.produceUnitNameToUnitWithCount[unit.unitType].count
+    local unitsInBuildingArea = _getUnitsInsideBuildArea()
+
+    -- add faction abilities
+    if playerColor then
+        local playerFaction = _factionHelper.fromColor(playerColor)
+        
+        if playerFaction then
+            for _, factionAbility in ipairs(playerFaction.abilities) do
+                local abilityEffect = FACTION_EFFECTS[factionAbility]
+                if abilityEffect then
+                    result.amalgamation = result.amalgamation or abilityEffect.amalgamation
+
+                    -- Faction abilities may require a color on tokens
+                    unitsInBuildingArea = _unitHelper.fillUnitColors(unitsInBuildingArea)
+                end
+            end
         end
-        result.produceUnitNameToUnitWithCount[unit.unitType] = unit
+    end
+
+    for _, unit in ipairs(unitsInBuildingArea) do
+        -- Count unit for building player if we're lacking any color info, or if unit color matches player color
+        if not playerColor or not unit.color or unit.color == playerColor then
+            if result.produceUnitNameToUnitWithCount[unit.unitType] then
+                unit.count = unit.count + result.produceUnitNameToUnitWithCount[unit.unitType].count
+            end
+            result.produceUnitNameToUnitWithCount[unit.unitType] = unit
+        -- If unit color doesn't match and amalgamation is active, create free-unit effects for the unit type
+        elseif result.amalgamation and playerColor and unit.color ~= playerColor then
+            local amalgamationForUnitType = result.unitOverrides['Amalgamation ' .. unit.unitType]
+            if not amalgamationForUnitType then
+                amalgamationForUnitType = {
+                    effectName = 'Amalgamation ' .. unit.unitType,
+                    unitTypes = { unit.unitType },
+                    freeCostUnits = 0,
+                }
+                result.unitOverrides['Amalgamation ' .. unit.unitType] = amalgamationForUnitType
+            end
+            amalgamationForUnitType.freeCostUnits = (amalgamationForUnitType.freeCostUnits or 0) + 1
+        end
     end
 
     local function addItem(name)
@@ -547,9 +619,16 @@ function getProduceConsumeItems()
             if objectEffects.objectEffectsOverrides then
                 result.objectEffectsOverrides = CrLua.Table.join(result.objectEffectsOverrides, objectEffects.objectEffectsOverrides)
             end
+            if objectEffects.unitOverrides then
+                objectEffects.unitOverrides.effectName = name
+                result.unitOverrides[name] = objectEffects.unitOverrides
+            end
             result.sarween = result.sarween or objectEffects.sarween
             result.hegemonic = result.hegemonic or objectEffects.hegemonic
             result.warmachine = result.warmachine or objectEffects.warmachine
+            if objectEffects.aiDevelopmentAlgorithm and not result.aiDevelopmentAlgorithm then
+                result.aiDevelopmentAlgorithm = #(unitUpgrades or {})
+            end
         end
     end
 
@@ -565,6 +644,34 @@ function getProduceConsumeItems()
 
     CrLua.Log.d(TAG, 'getProduceConsumeItems', result)
     return result
+end
+
+local function getUnitOverridesByUnitType(unitOverridesByEffect)
+    -- Map unit overrides to unit type
+    -- Make local copies of  data so we can modify it while processing
+    local unitOverridesByType = {}
+    for _, unitOverride in pairs(produceConsumeItems.unitOverrides or {}) do
+        local copiedUnitOverride = {
+            effectName = name,
+            unitTypes = unitOverride.unitTypes,
+            freeProductionUnits = unitOverride.freeProductionUnits,
+            freeCostUnits = unitOverride.freeCostUnits,
+            productionRateMultiplier = unitOverride.productionRateMultiplier,
+            costRateMultiplier = unitOverride.costRateMultiplier,
+        }
+
+        for _, type in ipairs(unitOverride.unitTypes) do
+            local overridesForUnitType = unitOverridesByType[type]
+            if not overridesForUnitType then
+                overridesForUnitType = {}
+                unitOverridesByType[type] = overridesForUnitType
+            end
+
+            table.insert(overridesForUnitType, copiedUnitOverride)
+        end
+    end
+
+    return unitOverridesByType
 end
 
 function getProduceConsumeResourcesAndCost(produceConsumeItems)
@@ -593,8 +700,41 @@ function getProduceConsumeResourcesAndCost(produceConsumeItems)
 
     for unitType, unit in pairs(produceConsumeItems.produceUnitNameToUnitWithCount) do
         local unitAttrs = _getUnitAttributes(unit.unitType)
-        result.cost = result.cost + math.ceil(unit.count * (unitAttrs.cost or 0))
-        result.numUnits = result.numUnits + unit.count
+        local costCount = unit.count or 0
+        local costRate = unitAttrs.cost or 0
+        local productionCount = unit.count or 0
+        local productionRate = 1.0
+
+        --TODO: This DOES NOT combine well. We need to apply the flat reduction AFTER any multiplicative reductions, choosing the best rate.
+        for _, unitOverride in ipairs(unitOverridesByType[unit.unitType] or {}) do
+            if unitOverride.freeCostUnits then
+                local initialCostCount = costCount
+                costCount = math.max(costCount - unitOverride.freeCostUnits, 0)
+
+                --preserve leftover cost reduction for the other units
+                unitOverride.freeCostUnits = unitOverride.freeCostUnits - (initialCostCount - costCount)
+            end
+            if unitOverride.freeProductionUnits then
+                local initialProductionCount = productionCount
+                productionCount = math.max(productionCount - unitOverride.freeProductionUnits, 0)
+
+                --preserve leftover production reduction for the other units
+                unitOverride.freeProductionUnits = unitOverride.freeProductionUnits - (initialProductionCount - productionCount)
+            end
+            if unitOverride.productionRateMultiplier then
+                productionRate = productionRate * unitOverride.productionRateMultiplier
+            end
+            if unitOverride.costRateMultiplier then
+                costRate = costRate * unitOverride.costRateMultiplier
+            end
+        end
+
+        result.cost = result.cost + math.ceil(costCount * (costRate or 0))
+        result.numUnits = result.numUnits + math.ceil(productionCount * productionRate)
+    end
+
+    if produceConsumeItems.aiDevelopmentAlgorithm then
+        result.cost = math.max(result.cost - produceConsumeItems.aiDevelopmentAlgorithm, 0)
     end
 
     -- If Hegemonic Trade Policy (swap resouce/influence values), replace
@@ -729,7 +869,6 @@ function drawBoundingBox()
                 end
             end
         end
-
 
     end
 

--- a/Objects/TI4_BuildArea.ttslua
+++ b/Objects/TI4_BuildArea.ttslua
@@ -39,7 +39,6 @@ local OBJECT_EFFECTS = {
         hegemonic = true,
     },
     ['AI Development Algorithm'] = {
-        requireFaceUp = true,
         aiDevelopmentAlgorithm = true
     },
 
@@ -597,12 +596,22 @@ function getProduceConsumeItems()
         end
     end
 
-    if result.aiDevelopmentAlgorithm and playerColor then
+    for object, _ in pairs(objects) do
+        if object.tag == 'Deck' then
+            for _, entry in ipairs(object.getObjects()) do
+                addItem(entry.name)
+            end
+        else
+            addItem(object.getName())
+        end
+    end
+
+    if result.aiDevelopmentAlgorithm then
         -- Detect unit upgrades (AI Development Algorithm)
         local unitUpgrades = {}
         for _, object in ipairs(getAllObjects()) do
             if not inHandGuidSet[object.getGUID()] and not object.is_face_down and object.tag == 'Card'
-                and _zoneHelper.zoneFromPosition(object.getPosition()) == playerColor then
+                and playerColor and _zoneHelper.zoneFromPosition(object.getPosition()) == playerColor then
                 local objectName = object.getName()
 
                 if _unitHelper.isUnitUpgradeName(objectName) then
@@ -612,16 +621,6 @@ function getProduceConsumeItems()
         end
 
         result.aiDevelopmentAlgorithm = #unitUpgrades
-    end
-
-    for object, _ in pairs(objects) do
-        if object.tag == 'Deck' then
-            for _, entry in ipairs(object.getObjects()) do
-                addItem(entry.name)
-            end
-        else
-            addItem(object.getName())
-        end
     end
 
     CrLua.Log.d(TAG, 'getProduceConsumeItems', result)
@@ -989,6 +988,7 @@ function announce(items, resourcesAndCost)
     assert(type(items) == 'table' and type(resourcesAndCost) == 'table')
     CrLua.Log.d(TAG, 'announce')
     local produce = {}
+    local amalgamated = {}
     for unitType, unit in pairs(items.produceUnitNameToUnitWithCount) do
         if unit.count > 1 then
             if unitType ~= 'Infantry' then
@@ -1012,6 +1012,25 @@ function announce(items, resourcesAndCost)
     end
     if tradegoods > 0 then
         table.insert(consume, tradegoods .. ' tradegood' .. (tradegoods > 1 and 's' or ''))
+    end
+    if items.amalgamation then
+        for unitType, consumedAmount in pairs(items.amalgamation) do
+            local unitTypeProduced = items.produceUnitNameToUnitWithCount[unitType] and items.produceUnitNameToUnitWithCount[unitType].count or 0
+
+            if consumedAmount and consumedAmount > 0 then
+                local leftoverAmalgamation = consumedAmount - unitTypeProduced
+                if leftoverAmalgamation > 0 then
+                    table.insert(amalgamated, unitTypeProduced .. 'x ' .. unitType .. ' consumed (' .. leftoverAmalgamation .. ' leftover)')
+                else
+                    table.insert(amalgamated, consumedAmount .. 'x ' .. unitType .. ' consumed')
+                end
+            end
+        end
+
+        table.insert(consume, 'Amalgamation: ' .. table.concat(amalgamated, '; '))
+    end
+    if items.aiDevelopmentAlgorithm then
+        table.insert(consume, 'AI Development Algorithm (' .. items.aiDevelopmentAlgorithm .. ')' )
     end
 
     local message = table.concat({

--- a/Objects/TI4_BuildArea.ttslua
+++ b/Objects/TI4_BuildArea.ttslua
@@ -39,6 +39,7 @@ local OBJECT_EFFECTS = {
         hegemonic = true,
     },
     ['AI Development Algorithm'] = {
+        requireFaceUp = true,
         aiDevelopmentAlgorithm = true
     },
 
@@ -502,30 +503,8 @@ function getProduceConsumeItems()
     CrLua.Log.d(TAG, 'getProduceConsumeItems')
     local playerColor = _data.playerColor
 
-    local inHandGuidSet = _zoneHelper.inHand()
-
-    -- Detect unit upgrades (AI Development Algorithm) and Alliance promissory notes
-
-    local playerAlliancePromissoryNotes = {}
-    local unitUpgrades = {}
-    for _, object in ipairs(getAllObjects()) do
-        if not inHandGuidSet[object.getGUID()] and not object.is_face_down and object.tag == 'Card'
-            and playerColor and _zoneHelper.zoneFromPosition(object.getPosition()) == playerColor then
-            local objectName = object.getName()
-
-            local colorMatch = string.match(objectName, '^Alliance %((%a+)%)$')
-            if colorMatch and colorMatch ~= playerColor then
-                playerAlliancePromissoryNotes[colorMatch] = true
-            end
-
-            if _unitHelper.isUnitUpgradeName(objectName) then
-                table.insert(unitUpgrades, objectName)
-            end
-        end
-    end
-
     -- Get objects to consider.
-    
+    local inHandGuidSet = _zoneHelper.inHand()    
     local objects = CrLua.Table.join(_data.inside, {})
     local function useOutsizeBuildAreaObject(object)
         local objectEffects = OBJECT_EFFECTS[object.getName()]
@@ -543,9 +522,7 @@ function getProduceConsumeItems()
         end
         if objectEffects.anywhereInPlayerZone then
             local zoneColor = _zoneHelper.zoneFromPosition(object.getPosition())
-            local fromPlayer = playerColor and zoneColor == playerColor
-            local fromAlliance = objectEffects.viaAlliance and playerAlliancePromissoryNotes[zoneColor]
-            return fromPlayer or fromAlliance
+            return playerColor and zoneColor == playerColor
         end
         return objectEffects.anywhereOnTable
     end
@@ -559,7 +536,6 @@ function getProduceConsumeItems()
         consumeObjectNameToCount = {},
         produceUnitNameToUnitWithCount = {},
         objectEffectsOverrides = {},
-        unitOverrides = {},
         sarween = false,
         hegemonic = false,
         warmachine = false,
@@ -614,17 +590,28 @@ function getProduceConsumeItems()
             if objectEffects.objectEffectsOverrides then
                 result.objectEffectsOverrides = CrLua.Table.join(result.objectEffectsOverrides, objectEffects.objectEffectsOverrides)
             end
-            if objectEffects.unitOverrides then
-                objectEffects.unitOverrides.effectName = name
-                result.unitOverrides[name] = objectEffects.unitOverrides
-            end
             result.sarween = result.sarween or objectEffects.sarween
             result.hegemonic = result.hegemonic or objectEffects.hegemonic
             result.warmachine = result.warmachine or objectEffects.warmachine
-            if objectEffects.aiDevelopmentAlgorithm and not result.aiDevelopmentAlgorithm then
-                result.aiDevelopmentAlgorithm = #(unitUpgrades or {})
+            result.aiDevelopmentAlgorithm = result.aiDevelopmentAlgorithm or objectEffects.aiDevelopmentAlgorithm
+        end
+    end
+
+    if result.aiDevelopmentAlgorithm and playerColor then
+        -- Detect unit upgrades (AI Development Algorithm)
+        local unitUpgrades = {}
+        for _, object in ipairs(getAllObjects()) do
+            if not inHandGuidSet[object.getGUID()] and not object.is_face_down and object.tag == 'Card'
+                and _zoneHelper.zoneFromPosition(object.getPosition()) == playerColor then
+                local objectName = object.getName()
+
+                if _unitHelper.isUnitUpgradeName(objectName) then
+                    table.insert(unitUpgrades, objectName)
+                end
             end
         end
+
+        result.aiDevelopmentAlgorithm = #unitUpgrades
     end
 
     for object, _ in pairs(objects) do
@@ -639,34 +626,6 @@ function getProduceConsumeItems()
 
     CrLua.Log.d(TAG, 'getProduceConsumeItems', result)
     return result
-end
-
-local function getUnitOverridesByUnitType(unitOverridesByEffect)
-    -- Map unit overrides to unit type
-    -- Make local copies of  data so we can modify it while processing
-    local unitOverridesByType = {}
-    for _, unitOverride in pairs(produceConsumeItems.unitOverrides or {}) do
-        local copiedUnitOverride = {
-            effectName = name,
-            unitTypes = unitOverride.unitTypes,
-            freeProductionUnits = unitOverride.freeProductionUnits,
-            freeCostUnits = unitOverride.freeCostUnits,
-            productionRateMultiplier = unitOverride.productionRateMultiplier,
-            costRateMultiplier = unitOverride.costRateMultiplier,
-        }
-
-        for _, type in ipairs(unitOverride.unitTypes) do
-            local overridesForUnitType = unitOverridesByType[type]
-            if not overridesForUnitType then
-                overridesForUnitType = {}
-                unitOverridesByType[type] = overridesForUnitType
-            end
-
-            table.insert(overridesForUnitType, copiedUnitOverride)
-        end
-    end
-
-    return unitOverridesByType
 end
 
 function getProduceConsumeResourcesAndCost(produceConsumeItems)
@@ -695,37 +654,6 @@ function getProduceConsumeResourcesAndCost(produceConsumeItems)
 
     for unitType, unit in pairs(produceConsumeItems.produceUnitNameToUnitWithCount) do
         local unitAttrs = _getUnitAttributes(unit.unitType)
-        local costCount = unit.count or 0
-        local costRate = unitAttrs.cost or 0
-        local productionCount = unit.count or 0
-        local productionRate = 1.0
-
-        --TODO: This DOES NOT combine well. We need to apply the flat reduction AFTER any multiplicative reductions, choosing the best rate.
-        for _, unitOverride in ipairs(unitOverridesByType[unit.unitType] or {}) do
-            if unitOverride.freeCostUnits then
-                local initialCostCount = costCount
-                costCount = math.max(costCount - unitOverride.freeCostUnits, 0)
-
-                --preserve leftover cost reduction for the other units
-                unitOverride.freeCostUnits = unitOverride.freeCostUnits - (initialCostCount - costCount)
-            end
-            if unitOverride.freeProductionUnits then
-                local initialProductionCount = productionCount
-                productionCount = math.max(productionCount - unitOverride.freeProductionUnits, 0)
-
-                --preserve leftover production reduction for the other units
-                unitOverride.freeProductionUnits = unitOverride.freeProductionUnits - (initialProductionCount - productionCount)
-            end
-            if unitOverride.productionRateMultiplier then
-                productionRate = productionRate * unitOverride.productionRateMultiplier
-            end
-            if unitOverride.costRateMultiplier then
-                costRate = costRate * unitOverride.costRateMultiplier
-            end
-        end
-
-        result.cost = result.cost + math.ceil(costCount * (costRate or 0))
-        result.numUnits = result.numUnits + math.ceil(productionCount * productionRate)
         -- If amalgamation is present, find how many units whose cost should be ignored.
         local amalgamatedUnitsOfType = produceConsumeItems.amalgamation and produceConsumeItems.amalgamation[unit.unitType] or 0
 

--- a/Objects/TI4_BuildArea.ttslua
+++ b/Objects/TI4_BuildArea.ttslua
@@ -238,7 +238,7 @@ local function _updateUnitAttributes(produceUnitNameToUnitWithCount)
         unitAttrs = assert(unitAttrs),
         myColor = color or 'Grey',
         myUnitModifiers = unitModifiers,
-        myUnitTypeToCount = unitTypeToCount,
+        myUnitTypeToCount = unitTypeToCount or {},
         opponentColor = false,
         opponentUnitModifiers = false,
         opponentUnitTypeToCount = false
@@ -516,7 +516,7 @@ function getProduceConsumeItems()
     local playerColor = _data.playerColor
 
     -- Get objects to consider.
-    local inHandGuidSet = _zoneHelper.inHand()    
+    local inHandGuidSet = _zoneHelper.inHand()
     local objects = CrLua.Table.join(_data.inside, {})
     local function useOutsizeBuildAreaObject(object)
         local objectEffects = OBJECT_EFFECTS[object.getName()]
@@ -533,8 +533,7 @@ function getProduceConsumeItems()
             return false
         end
         if objectEffects.anywhereInPlayerZone then
-            local zoneColor = _zoneHelper.zoneFromPosition(object.getPosition())
-            return playerColor and zoneColor == playerColor
+            return playerColor and _zoneHelper.zoneFromPosition(object.getPosition()) == playerColor
         end
         return objectEffects.anywhereOnTable
     end
@@ -1004,7 +1003,6 @@ function announce(items, resourcesAndCost)
     assert(type(items) == 'table' and type(resourcesAndCost) == 'table')
     CrLua.Log.d(TAG, 'announce')
     local produce = {}
-    local amalgamated = {}
     for unitType, unit in pairs(items.produceUnitNameToUnitWithCount) do
         if unit.count > 1 then
             if unitType ~= 'Infantry' then
@@ -1030,6 +1028,8 @@ function announce(items, resourcesAndCost)
         table.insert(consume, tradegoods .. ' tradegood' .. (tradegoods > 1 and 's' or ''))
     end
     if items.amalgamation then
+        local amalgamated = {}
+        
         for unitType, consumedAmount in pairs(items.amalgamation) do
             local unitTypeProduced = items.produceUnitNameToUnitWithCount[unitType] and items.produceUnitNameToUnitWithCount[unitType].count or 0
 

--- a/Objects/TI4_BuildArea.ttslua
+++ b/Objects/TI4_BuildArea.ttslua
@@ -212,6 +212,19 @@ function _getUnitAttributes(unitType)
         return _unitAttributes[unitType]
     end
 
+    _updateUnitAttributes()
+
+    return _unitAttributes[unitType]
+end
+
+local function _updateUnitAttributes(produceUnitNameToUnitWithCount)
+    assert(not produceUnitNameToUnitWithCount or type(produceUnitNameToUnitWithCount) == 'table')
+
+    local unitTypeToCount = {}
+    for unitType, unit in pairs(produceUnitNameToUnitWithCount or {}) do
+        unitTypeToCount[unitType] = unit.count
+    end
+
     local color = getPlayerColor()
 
     local unitOverrides = _unitHelper.getColorToUnitOverrides()[color] or {}
@@ -225,7 +238,7 @@ function _getUnitAttributes(unitType)
         unitAttrs = assert(unitAttrs),
         myColor = color or 'Grey',
         myUnitModifiers = unitModifiers,
-        myUnitTypeToCount = {},
+        myUnitTypeToCount = unitTypeToCount,
         opponentColor = false,
         opponentUnitModifiers = false,
         opponentUnitTypeToCount = false
@@ -233,8 +246,8 @@ function _getUnitAttributes(unitType)
 
     _unitAttributes = unitAttrs
     _unitAttributesLastUpdateTime = Time.time
-    return _unitAttributes[unitType]
 end
+
 
 function _getProduction()
     local spaceDock = _getUnitAttributes('Space Dock')
@@ -651,13 +664,16 @@ function getProduceConsumeResourcesAndCost(produceConsumeItems)
         end
     end
 
+    _updateUnitAttributes(produceConsumeItems.produceUnitNameToUnitWithCount)
+
     for unitType, unit in pairs(produceConsumeItems.produceUnitNameToUnitWithCount) do
         local unitAttrs = _getUnitAttributes(unit.unitType)
         -- If amalgamation is present, find how many units whose cost should be ignored.
         local amalgamatedUnitsOfType = produceConsumeItems.amalgamation and produceConsumeItems.amalgamation[unit.unitType] or 0
+        local productionConsumed = math.ceil(unit.count * (unitAttrs.productionConsumed or 1)) - (unitAttrs.freeProduction or 0)
 
         result.cost = result.cost + math.ceil(math.max(unit.count - amalgamatedUnitsOfType, 0) * (unitAttrs.cost or 0))
-        result.numUnits = result.numUnits + unit.count
+        result.numUnits = result.numUnits + productionConsumed
     end
 
     if produceConsumeItems.aiDevelopmentAlgorithm then

--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -477,8 +477,16 @@ local _unitModifiers = {
         owner = OWNER.SELF,
         type = TYPE.ADJUST,
         apply = function(unitAttrs)
-            -- We won't know production amount while applying modifiers, so tell the Build tool to handle it.
-            unitAttrs['Infantry'].extraUnitWhenProduced = true
+            local currentCost = unitAttrs['Infantry'].cost
+            local currentProductionConsumed = unitAttrs['Infantry'].productionConsumed or 1
+            local currentUnitsPerResource = math.floor(0.5 + (1.0 / currentCost)) --simulate math.round
+
+            local newUnitsPerResource = currentUnitsPerResource + 1
+            local newCost = 1.0 / newUnitsPerResource
+            local newProductionConsumed = (newCost / currentCost) * currentProductionConsumed
+
+            unitAttrs['Infantry'].cost = newCost
+            unitAttrs['Infantry'].productionConsumed = newProductionConsumed
         end
     },
 
@@ -614,9 +622,17 @@ local _unitModifiers = {
         leader = LEADER.COMMANDER, -- Naalu
         owner = OWNER.SELF,
         type = TYPE.ADJUST,
-        apply = function(unitAttrs)
-            -- We won't know production amount while applying modifiers, so tell the Build tool to handle it.
-            unitAttrs['Fighter'].extraUnitWhenProduced = true
+        apply = function(unitAttrs, params)
+            local currentCost = unitAttrs['Fighter'].cost or 0.5
+            local currentProductionConsumed = unitAttrs['Fighter'].productionConsumed or 1
+            local currentUnitsPerResource = math.floor(0.5 + (1.0 / currentCost)) --simulate math.round
+
+            local newUnitsPerResource = currentUnitsPerResource + 1
+            local newCost = 1.0 / newUnitsPerResource
+            local newProductionConsumed = (newCost / currentCost) * currentProductionConsumed
+
+            unitAttrs['Fighter'].cost = newCost
+            unitAttrs['Fighter'].productionConsumed = newProductionConsumed
         end
     },
 
@@ -754,7 +770,7 @@ local _unitModifiers = {
     ['Regulated Conscription'] = {
         description = 'Fighters and infantry cost 1 each',
         owner = OWNER.SELF,
-        type = TYPE.ADJUST,
+        type = TYPE.MUTATE, -- set cost before additional adjustments
         apply = function(unitAttrs)
             unitAttrs['Fighter'].cost = 1
             unitAttrs['Infantry'].cost = 1
@@ -889,9 +905,20 @@ local _unitModifiers = {
         leader = LEADER.COMMANDER, -- Vuil'Raith
         owner = OWNER.SELF,
         type = TYPE.CHOOSE,
-        apply = function(unitAttrs)
-            -- Because of Regulated Conscription and other commander abilities, this needs to be figured out with actual build amounts.
-            -- We don't know production quantity at this point, so let the Build Area Tool detect and figure this out.
+        apply = function(unitAttrs, params)
+            local bonusRemaining = 2
+            for _, unitType in ipairs({'Infantry', 'Fighter'}) do
+                local unitTypeAttrs = unitAttrs[unitType]
+                local produceAmount = (params.myUnitTypeToCount[unitType] or 0)
+                local productionConsumed = math.ceil(produceAmount * (unitTypeAttrs.productionConsumed or 1))
+
+                if productionConsumed > 0 then
+                    local applyBonusAmount = math.min(productionConsumed, bonusRemaining)
+                    bonusRemaining = bonusRemaining - applyBonusAmount
+
+                    unitTypeAttrs.freeProduction = applyBonusAmount
+                end
+            end
         end
     },
 
@@ -918,7 +945,7 @@ local _unitModifiers = {
     },
 
     ['Trrakan Aun Zulok'] = {
-        leader = LEADER.COMMANDER, -- Strike Wing
+        leader = LEADER.COMMANDER, -- Argent Flight
         description = '+1 die to a unit ability (anti-fighter barrage, bombardment, space cannon)',
         owner = OWNER.SELF,
         type = TYPE.CHOOSE,

--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -1504,6 +1504,11 @@ function _init()
     end
 end
 
+function isUnitUpgradeName(name)
+    assert(type(name) == 'string')
+    return _unitOverrides[name] and _unitOverrides[name].upgrade and true or false
+end
+
 function isUnitName(name)
     assert(type(name) == 'string')
     return _objectNameToUnitData[name] and true or false

--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -471,6 +471,17 @@ local _unitModifiers = {
         end
     },
 
+    ['Brother Omar'] = {
+        description = 'Produce an additional Infantry for their cost; it doesn\'t count towards production limits.',
+        leader = LEADER.COMMANDER, -- Yin
+        owner = OWNER.SELF,
+        type = TYPE.ADJUST,
+        apply = function(unitAttrs)
+            -- We won't know production amount while applying modifiers, so tell the Build tool to handle it.
+            unitAttrs['Infantry'].extraUnitWhenProduced = true
+        end
+    },
+
     ['Bunker'] = {
         description = '-4 to all BOMBARDMENT rolls',
         owner = OWNER.ANY,
@@ -596,6 +607,17 @@ local _unitModifiers = {
         end
     },
 
+    ["M'aban"] = {
+        description = 'Produce an additional Fighter for their cost; it doesn\'t count towards production limits.',
+        leader = LEADER.COMMANDER, -- Naalu
+        owner = OWNER.SELF,
+        type = TYPE.ADJUST,
+        apply = function(unitAttrs)
+            -- We won't know production amount while applying modifiers, so tell the Build tool to handle it.
+            unitAttrs['Fighter'].extraUnitWhenProduced = true
+        end
+    },
+
     ['Morale Boost'] = {
         description = '+1 to all COMBAT rolls',
         owner = OWNER.SELF,
@@ -651,6 +673,16 @@ local _unitModifiers = {
                     attrs.spaceCombat.hit = attrs.spaceCombat.hit - 2
                 end
             end
+        end
+    },
+
+    ['Navarch Feng'] = {
+        description = 'You can produce your flagship without spending resources.',
+        leader = LEADER.COMMANDER, -- Nomad
+        owner = OWNER.SELF,
+        type = TYPE.ADJUST,
+        apply = function(unitAttrs) 
+            unitAttrs['Flagship'].cost = 0
         end
     },
 
@@ -845,6 +877,17 @@ local _unitModifiers = {
                 end
             end
 
+        end
+    },
+
+    ['That Which Molds Flesh'] = {
+        description = 'When producing Infantry and/or Fighters, up to 2 do not count against the production limit.',
+        leader = LEADER.COMMANDER, -- Vuil'Raith
+        owner = OWNER.SELF,
+        type = TYPE.CHOOSE,
+        apply = function(unitAttrs)
+            -- Because of Regulated Conscription and other commander abilities, this needs to be figured out with actual build amounts.
+            -- We don't know production quantity at this point, so let the Build Area Tool detect and figure this out.
         end
     },
 


### PR DESCRIPTION
Adds the following to the Build Area Tool:
- Tech: AI Development Algorithm
  - Put the tech inside the build area to use it. It counts unit upgrades in the player's zone if present, and subtracts from the final cost.
- The tool now passes `myUnitTypeToCount` using the unit build amounts to the Unit Helper, so Commanders can correctly affect them. (Count matters for Vuil'Raith commander only)
- Regulated Conscription is a MUTATE; this effect needs to be applied before other changes (or needs to be much more math-y)
- Commander: Navarch Feng (Nomad)
  - Sets flagship cost to 0
- Commander: Brother Omar (Yin)
  - Sets Infantry cost to provide an additional plastic piece from the current cost (math accounts for Regulated Conscription)
  - Set new `productionConsumed` attribute, which controls the production consumed per unit built. 
    - This defaults to 1 mostly, but with Brother Omar becomes 2/3 for Infantry without Regulated Conscription
- Commander: M'aban (Naalu): Same as Brother Omar, but for Fighters
- Commander: That Which Molds Flesh (Vuil'Raith)
  - For Infantry+Fighters, check units produced (accounting for productionConsumed) to determine if any produced units should be free. Sets another new `freeProduction` attribute on these units, which the Build Area Tool checks to reduce final build cost.

Also, Vuil'Raith's Amalgamation is now correctly announced (along with AI Development Algorithm)

Screenshot shows basic function. 1x figher and 1x infantry are totally free. Num Units is reduced from 5 to 3 by Vuil'Raith commander.
![commander-build-area](https://user-images.githubusercontent.com/2775535/100179688-86710480-2ea4-11eb-9156-6a769f941337.png)


This time with Regulated Conscription (and Imperia). Yin commander makes 4 infantry cost 2res/2prod. 2 fighters cost 2res/2prod. Flagship with Nomad commander costs 0res/1prod. AI Dev Algs reduces final resource cost from 4 to 2. Vuil'Raith commander reduces final prod consumed from 5 to 3.
![image](https://user-images.githubusercontent.com/2775535/100179677-7e18c980-2ea4-11eb-8b1a-0e6e9c6ce77e.png)
