### PR TITLE
Hero abilities (+ frontier token placement)

### DIFF
--- a/Objects/TI4_Helpers/TI4_ExploreHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_ExploreHelper.ttslua
@@ -149,6 +149,23 @@ function explorePlanet(tileGUID, planetName)
     broadcastToAll('Exploring Planet: ' .. planetName)
 end
 
+local _frontierTokenBagObject = nil
+function getFrontierTokenBag()
+    if _frontierTokenBagObject then
+        return _frontierTokenBagObject
+    end
+
+    local frontierTokenBagName = 'Frontier Tokens Bag'
+    for _, object in ipairs(getAllObjects()) do
+        if object.tag == 'Bag' and string.match(object.getName(), '^' .. frontierTokenBagName .. '$') then
+            _frontierTokenBagObject = object
+            return _frontierTokenBagObject
+        end
+    end
+
+    assert(false, 'Unable to locate bag with name "' .. frontierTokenBagName .. '"')
+end
+
 function exploreFrontier(token)
     local tokenPos = token.getPosition()
     local tokenRot = token.getRotation()
@@ -165,8 +182,11 @@ function exploreFrontier(token)
         frontierDeck.setPosition({tokenPos.x, tokenPos.y + 1, tokenPos.z})
         frontierDeck.setRotation({tokenRot.x, tokenRot.y, 0})
     end
+
+    local frontierTokenBag = assert(getFrontierTokenBag())
+    frontierTokenBag.putObject(token)
+
     broadcastToAll('Exploring Frontier Token')
-    token.destruct()
 end
 
 function checkCardForToken(object_spawned, tileGUID, planetName)
@@ -209,4 +229,80 @@ end
 
 function isFrontierToken(object)
     return object.tag == 'Generic' and object.getName() == 'Frontier Token'
+end
+
+function getAllFrontierTokens()
+    local frontierTokens = {}
+
+    for _, object in ipairs(getAllObjects()) do
+        if isFrontierToken(object) then
+            table.insert(frontierTokens, object)
+        end
+    end
+
+    return frontierTokens
+end
+
+-------------------------------------------------------------------------------
+
+-- Default position is slightly right of center
+local DEFAULT_FRONTIER_TOKEN_POSITION = { x = -1, y = 0, z = 0 }
+
+function systemShouldGetFrontierToken(system)
+    if system.planets and #system.planets > 0 then
+        return false
+    end
+    if system.hyperlane == true then
+        return false
+    end
+
+    return true
+end
+
+function placeFrontierTokens()
+    local frontierTokenBag = assert(getFrontierTokenBag())
+
+    local guidToSystem = _systemHelper.systems()
+    local emptySystemObjects = {}
+    local frontierTokenObjectsToPosition = {}
+    for _, object in ipairs(getAllObjects()) do
+        local system = guidToSystem[object.getGUID()]
+        -- Collect all system tiles that are 'empty'
+        if system and systemShouldGetFrontierToken(system) then
+            table.insert(emptySystemObjects, object)
+        -- Collect all current frontier tokens
+        elseif isFrontierToken(object) then
+            frontierTokenObjectsToPosition[object.getGUID()] = object.getPosition()
+        end
+    end
+
+    -- Find set of system tiles containing frontier tokens
+    local frontierTokenObjectsToSystem = _systemHelper.systemsFromPositions(frontierTokenObjectsToPosition)
+    local frontierContainingSystems = {}
+    for frontierTokenObject, systemTile in pairs(frontierTokenObjectsToSystem) do
+        if systemTile then
+            frontierContainingSystems[systemTile.guid] = true
+        end
+    end
+
+    for _, emptySystemObject in ipairs(emptySystemObjects) do
+        if not frontierContainingSystems[emptySystemObject.getGUID()] then
+            local tilePlacementPos = emptySystemObject.positionToWorld(DEFAULT_FRONTIER_TOKEN_POSITION)
+            frontierTokenBag.takeObject({
+                position = { x = tilePlacementPos.x, y = tilePlacementPos.y + 3, z = tilePlacementPos.z },
+                smooth   = true,
+            })
+        end
+    end
+end
+
+function retrieveFrontierTokens()
+    local frontierTokenBag = assert(getFrontierTokenBag())
+
+    -- Grab all frontier tokens, from everywhere.
+    for _, object in ipairs(getAllObjects()) do
+        if isFrontierToken(object) then
+            frontierTokenBag.putObject(object)
+        end
+    end
 end

--- a/Objects/TI4_Helpers/TI4_ExploreHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_ExploreHelper.ttslua
@@ -149,17 +149,18 @@ function explorePlanet(tileGUID, planetName)
     broadcastToAll('Exploring Planet: ' .. planetName)
 end
 
-local _frontierTokenBagObject = nil
+local _frontierTokenBagGuid = nil
 function getFrontierTokenBag()
-    if _frontierTokenBagObject then
-        return _frontierTokenBagObject
+    local frontierTokenBagObject = getObjectFromGUID(_frontierTokenBagGuid)
+    if frontierTokenBagObject then
+        return frontierTokenBagObject
     end
 
     local frontierTokenBagName = 'Frontier Tokens Bag'
     for _, object in ipairs(getAllObjects()) do
         if object.tag == 'Bag' and string.match(object.getName(), '^' .. frontierTokenBagName .. '$') then
-            _frontierTokenBagObject = object
-            return _frontierTokenBagObject
+            _frontierTokenBagGuid = object.getGUID()
+            return object
         end
     end
 

--- a/Objects/TI4_Helpers/TI4_ExploreHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_ExploreHelper.ttslua
@@ -260,41 +260,54 @@ function systemShouldGetFrontierToken(system)
     return true
 end
 
-function placeFrontierTokens()
+function _placeFrontierTokensCoroutine()
     local frontierTokenBag = assert(getFrontierTokenBag())
 
     local guidToSystem = _systemHelper.systems()
-    local emptySystemObjects = {}
+    local emptySystemGuidToTokenPositions = {}
+    local emptySystemGuidToPosition = {}
     local frontierTokenObjectsToPosition = {}
     for _, object in ipairs(getAllObjects()) do
         local system = guidToSystem[object.getGUID()]
-        -- Collect all system tiles that are 'empty'
+        -- Collect all system tiles that are 'empty', along with the position a frontier token would go
         if system and systemShouldGetFrontierToken(system) then
-            table.insert(emptySystemObjects, object)
-        -- Collect all current frontier tokens
+            local tokenPosition = object.positionToWorld(DEFAULT_FRONTIER_TOKEN_POSITION)
+            emptySystemGuidToPosition[object.getGUID()] = object.getPosition()
+            emptySystemGuidToTokenPositions[object.getGUID()] = tokenPosition
+        -- Collect all current frontier token positions
         elseif isFrontierToken(object) then
             frontierTokenObjectsToPosition[object.getGUID()] = object.getPosition()
         end
     end
+    coroutine.yield(0)
 
-    -- Find set of system tiles containing frontier tokens
-    local frontierTokenObjectsToSystem = _systemHelper.systemsFromPositions(frontierTokenObjectsToPosition)
-    local frontierContainingSystems = {}
-    for frontierTokenObject, systemTile in pairs(frontierTokenObjectsToSystem) do
-        if systemTile then
-            frontierContainingSystems[systemTile.guid] = true
-        end
+    -- Find set of hex coordinates containing frontier tokens
+    local frontierTokenGuidToHex = _systemHelper.hexesFromPositions(frontierTokenObjectsToPosition)
+    local hexesWithFrontierTokens = {}
+    for _, hex in pairs(frontierTokenGuidToHex) do
+        hexesWithFrontierTokens[hex] = true
     end
 
-    for _, emptySystemObject in ipairs(emptySystemObjects) do
-        if not frontierContainingSystems[emptySystemObject.getGUID()] then
-            local tilePlacementPos = emptySystemObject.positionToWorld(DEFAULT_FRONTIER_TOKEN_POSITION)
+    -- Empty systems to hex coordinates
+    local emptySystemGuidToHex = _systemHelper.hexesFromPositions(emptySystemGuidToPosition)
+
+    -- For each empty system, if it's hex coordinate doesn't have a frontier token then place a new one.
+    for systemGuid, tokenPosition in pairs(emptySystemGuidToTokenPositions) do
+        if emptySystemGuidToHex[systemGuid] and not hexesWithFrontierTokens[emptySystemGuidToHex[systemGuid]] then
             frontierTokenBag.takeObject({
-                position = { x = tilePlacementPos.x, y = tilePlacementPos.y + 3, z = tilePlacementPos.z },
+                position = { x = tokenPosition.x, y = tokenPosition.y + 3, z = tokenPosition.z },
                 smooth   = true,
             })
+
+            coroutine.yield(0)
         end
     end
+
+    return 1
+end
+
+function placeFrontierTokens()
+    startLuaCoroutine(self, '_placeFrontierTokensCoroutine')
 end
 
 function retrieveFrontierTokens()

--- a/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
@@ -1128,17 +1128,18 @@ end
 
 -------------------------------------------------------------------------------
 
-local _purgeBagObject = nil
+local _purgeBagGuid = nil
 function getPurgeBag()
-    if _purgeBagObject then
-        return _purgeBagObject
+    local purgeBagObject = getObjectFromGUID(_purgeBagGuid)
+    if purgeBagObject then
+        return purgeBagObject
     end
 
     local purgeBagName = 'Purge Bag'
     for _, object in ipairs(getAllObjects()) do
         if object.tag == 'Bag' and string.match(object.getName(), '^' .. purgeBagName .. '$') then
-            _purgeBagObject = object
-            return _purgeBagObject
+            _purgeBagGuid = object.getGUID()
+            return object
         end
     end
 

--- a/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
@@ -1408,6 +1408,11 @@ function _procynHeroAbilityCoroutine()
         end
     end
 
+    -- Ensure we're not tracking frontier tokens anymore
+    for tokenGuid, _ in pairs(explorableTokenGuidToSystemGuid) do
+        _animatingGuids[tokenGuid] = nil
+    end
+
     return 1
 end
 

--- a/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
@@ -32,6 +32,10 @@ function getHelperClient(helperObjectName)
     return setmetatable({}, { __index = function(t, k) return getCallWrapper(k) end })
 end
 local _zoneHelper = getHelperClient('TI4_ZONE_HELPER')
+local _strategyCardHelper = getHelperClient('TI4_STRATEGY_CARD_HELPER')
+local _exploreHelper = getHelperClient('TI4_EXPLORE_HELPER')
+local _systemHelper = getHelperClient('TI4_SYSTEM_HELPER')
+local _unitHelper = getHelperClient('TI4_UNIT_HELPER')
 
 -- Per-faction attributes.  This helper will also add the following fields:
 -- - color (string) or nil if not in use.
@@ -50,7 +54,7 @@ local _factionAttributes = {
         abilities = { 'Mitosis' },
         units = { 'Letani Warrior I', 'Letani Warrior II', 'Letani Behemoth' },
         commander = 'Dirzuga Rophal',
-        hero = 'Letania Miasmiala'
+        hero = 'Letani Miasmiala'
     },
 
     ['The Barony Of Letnev'] = {
@@ -1122,6 +1126,703 @@ function tintTokens(params)
     end
 end
 
+-------------------------------------------------------------------------------
+
+local _purgeBagObject = nil
+function getPurgeBag()
+    if _purgeBagObject then
+        return _purgeBagObject
+    end
+
+    local purgeBagName = 'Purge Bag'
+    for _, object in ipairs(getAllObjects()) do
+        if object.tag == 'Bag' and string.match(object.getName(), '^' .. purgeBagName .. '$') then
+            _purgeBagObject = object
+            return _purgeBagObject
+        end
+    end
+
+    assert(false, 'Unable to locate bag with name "' .. purgeBagName .. '"')
+end
+
+local _factionCardNameToAbilityFunc = false
+local _purgeCardQueue = {}
+
+function purgeCard(cardObject)
+    assert(cardObject.tag == 'Card')
+
+    local inHandGuidSet = _zoneHelper.inHand()
+    assert(not inHandGuidSet[cardObject.getGUID()], 'Cannot purge cards that are in a player\'s hand.')
+
+    local purgeBagObject = assert(getPurgeBag())
+
+    --TODO: Maybe deck related stuff? Object deletion checks? Card locked stuff?
+
+    purgeBagObject.putObject(cardObject)
+    broadcastToAll('PURGING card \'' .. cardObject.getName() .. '\'')
+end
+
+local function _heroCardCanBeUsed(cardObject, usingColor)
+    if cardObject.tag ~= 'Card' then
+        print('Cannot use ' .. cardObject.getName() .. '. Hero abilities can only be used from cards.')
+        return false
+    end
+
+    if cardObject.is_face_down then
+        print('Cannot use ' .. cardObject.getName() .. '. Card is facedown; did you unlock it?')
+        return false
+    end
+
+    local inHandGuidSet = _zoneHelper.inHand()
+    if inHandGuidSet[cardObject.getGUID()] then
+        print('Cannot use ' .. cardObject.getName() .. '. Hero cards cannot be used while in your hand.')
+        return false
+    end
+
+    local factionColor = false
+    for color, faction in pairs(allFactions(false)) do
+        if faction.hero == cardObject.getName() then
+            factionColor = color
+            break
+        end
+    end
+    if not factionColor then
+        print('Cannot use ' .. cardObject.getName() .. '. No seated faction has this Hero.')
+        return false
+    end
+
+    if factionColor ~= usingColor and usingColor ~= 'Black' then
+        print('Cannot use ' .. cardObject.getName() .. '. ' .. usingColor .. ' cannot use ' .. factionColor .. '\'s Hero card.')
+        return false
+    end
+
+    -- Any other technical conditions that would prevent us from purging the card or executing the ability?
+    -- Any other gameplay situations that should prevent the Hero card from being used?
+
+    return true
+end
+
+local function _purgeHeroCard(owningObject, clickingColor)
+    if not _heroCardCanBeUsed(owningObject, clickingColor) then
+        -- Function will print why card cannot be used
+        return
+    end
+
+    purgeCard(owningObject)
+end
+
+local function _jacexHeroAbility(owningObject, clickingColor) --Sol Hero
+    if not _heroCardCanBeUsed(owningObject, clickingColor) then
+        -- Function will print why card cannot be used
+        return
+    end
+
+    local factionTokenName = false
+    for _, faction in pairs(allFactions(false)) do
+        if faction.hero == owningObject.getName() then
+            factionTokenName = faction.tokenName
+            break
+        end
+    end
+
+    assert(factionTokenName, 'Trying to invoke Jace X Hero Ability, but no faction with "Jace X, 4th Air Legion" is at the table.')
+
+    _strategyCardHelper.returnCommandTokensForFaction(factionTokenName)
+
+    if owningObject.tag == 'Card' then
+        purgeCard(owningObject)
+    end
+end
+
+local _procynHeroAbilityOwningObjectQueue = {}
+function _procynHeroAbilityCoroutine()
+    local owningObject = assert(table.remove(_procynHeroAbilityOwningObjectQueue))
+
+    -- Purge card before any wait loops
+    if owningObject.tag == 'Card' then
+        purgeCard(owningObject)
+    end
+
+    -- Place frontier tokens on systems that need one
+    _exploreHelper.placeFrontierTokens()
+
+    -- Wait for frontier tokens to land before exploring them.
+    local waitUntil = Time.time + 3
+    while Time.time < waitUntil do
+        coroutine.yield(0)
+    end
+
+    --Find faction owning this hero ability (and it's color)
+    local factionTokenName = false
+    local factionColor = false
+    for color, faction in pairs(allFactions(false)) do
+        if faction.hero == owningObject.getName() then
+            factionTokenName = faction.tokenName
+            factionColor = color
+            break
+        end
+    end
+    assert(factionTokenName and factionColor, 'Multiverse Shift: Placed Frontier Tokens, but cannot explore them with missing owning faction.')
+
+    --Map frontier tokens to system they're sitting on
+    local frontierTokens = _exploreHelper.getAllFrontierTokens()
+    local frontierTokenToPosition = {}
+    for _, token in ipairs(frontierTokens) do
+        frontierTokenToPosition[token] = token.getPosition()
+    end
+
+    local frontierTokenToSystem = _systemHelper.systemsFromPositions(frontierTokenToPosition)
+
+    --Find all units
+    local allUnits = _unitHelper.getUnits()
+
+    --Filter down to owning faction ships
+    --NOTE: Can skip units lacking faction/color; they'll be alongside other units.
+    local factionShipToPosition = {}
+    for _, unit in ipairs(allUnits) do
+        if unit.unitType ~= 'Infantry' and unit.unitType ~= 'Mech' and unit.unitType ~= 'Space Dock' and unit.unitType ~= 'PDS' then --ships only
+            if unit.factionTokenName and unit.factionTokenName == factionTokenName then
+                factionShipToPosition[unit.guid] = unit.position
+            elseif unit.color and unit.color == factionColor then
+                factionShipToPosition[unit.guid] = unit.position
+            end
+        end
+    end
+
+    --Find each system containing owning faction ship
+    local shipToSystem = _systemHelper.systemsFromPositions(factionShipToPosition)
+    local systemsWithFactionShipsSet = {}
+    for ship, system in pairs(shipToSystem) do
+        if system then
+            systemsWithFactionShipsSet[system.guid] = true
+        end
+    end
+
+    --For each system containing a frontier token AND owning faction ship, highlight the system tile
+    local explorableTokensToSystem = {}
+    local systemsToExplore = false
+    for token, system in pairs(frontierTokenToSystem) do
+        if system and systemsWithFactionShipsSet[system.guid] then
+            explorableTokensToSystem[token] = system
+            systemsToExplore = true
+        end
+    end
+
+    -- While there are still systems to explore, blink those system tiles with the player color (2 minute timeout)
+    local timeout = Time.time + 120
+    while Time.time < timeout and systemsToExplore do
+        systemsToExplore = false
+        for token, system in pairs(explorableTokensToSystem) do
+            -- See if token is still on table
+            if getObjectFromGUID(token.guid) then
+                local systemObject = getObjectFromGUID(system.guid)
+
+                systemObject.highlightOn(factionColor, 1)
+                systemsToExplore = true
+            end
+        end
+
+        -- Wait 2 seconds before repeating (1 sec on, 1 sec off)
+        local blinkWait = Time.time + 2
+        while Time.time < blinkWait do
+            coroutine.yield(0)
+        end
+    end
+
+    return 1
+end
+
+local function _procynHeroAbility(owningObject, clickingColor) --Empyrean Hero
+    if not _heroCardCanBeUsed(owningObject, clickingColor) then
+        -- Function will print why card cannot be used
+        return
+    end
+
+    table.insert(_procynHeroAbilityOwningObjectQueue, owningObject)
+    startLuaCoroutine(self, '_procynHeroAbilityCoroutine')
+end
+
+local _carrionHeroAbilityOwningObjectQueue = {}
+local _diceToBeRolled = {}
+function _carrionHeroAbilityCoroutine()
+    if #_diceToBeRolled > 0 then
+        print('Remove previously devoured ships before re-using Dimensional Anchor.')
+        return 1
+    end
+    local owningObject = assert(table.remove(_carrionHeroAbilityOwningObjectQueue))
+
+    --Find faction owning this hero ability (and it's color)
+    local factionTokenName = false
+    local factionColor = false
+    for color, faction in pairs(allFactions(false)) do
+        if faction.hero == owningObject.getName() then
+            factionTokenName = faction.tokenName
+            factionColor = color
+            break
+        end
+    end
+    assert(factionTokenName and factionColor, 'Dimensional Anchor: Trying to invoke Hero Ability, but no faction with "It Feeds on Carrion" is at the table.')
+
+    --Find each dimensional tear token
+    local dimensionalTearName = "Vuil'raith Cabal Gravity Rift Token"
+    local dimTokenToPosition = {}
+    local anyDimensionalTears = false
+    for _, object in ipairs(getAllObjects()) do
+        if object.tag == 'Tile' and string.match(object.getName(), '^' .. dimensionalTearName .. '$') then
+            dimTokenToPosition[object.getGUID()] = object.getPosition()
+            anyDimensionalTears = true
+        end
+    end
+
+    if not anyDimensionalTears then
+        print('Dimensional Anchor: No Dimensional Tear tokens found on the table. Won\'t use Hero Ability.')
+        return 1
+    end
+
+    --Find hex those tokens are on
+    local dimensionalTearToHex = _systemHelper.hexesFromPositions(dimTokenToPosition)
+
+    --Find set of hexes adjacent to above (including wormholes)
+    local hexToNeighboringHexes = {}
+    for _, hex in pairs(dimensionalTearToHex) do
+        local directlyAdjacentHexes = _systemHelper.hexNeighbors(hex)
+        local wormholeAdjacentHexes = _systemHelper.hexAdjacentWormholes({hex = hex, playerColor = factionColor})
+
+        local neighboringHexSet = {}
+        for _, adjHex in ipairs(directlyAdjacentHexes) do
+            neighboringHexSet[adjHex] = true
+        end
+        for _, adjHex in ipairs(wormholeAdjacentHexes) do
+            neighboringHexSet[adjHex] = true
+        end
+
+        local neighboringHexes = {}
+        for adjHex, _ in pairs(neighboringHexSet) do
+            table.insert(neighboringHexes, adjHex)
+        end
+
+        hexToNeighboringHexes[hex] = neighboringHexes
+    end
+
+    -- Get map of hex to system tile. Used to confirm a hex is actually placed on the table.
+    -- (neighboring hexes can be computed from math, regardless of the presence of a system tile)
+    local allHexesAsMap = {}
+    for _, hex in pairs(dimensionalTearToHex) do
+        allHexesAsMap[hex] = hex
+        for _, adjHex in ipairs(hexToNeighboringHexes[hex]) do
+            allHexesAsMap[adjHex] = adjHex
+        end
+    end
+
+    local allHexesToPosition = _systemHelper.hexesToPosition(allHexesAsMap)
+    local allHexesToSystemTiles = _systemHelper.systemsFromPositions(allHexesToPosition)
+
+    --Find all units on those hexes
+    local opponentShipToPosition = {}
+    local unitGuidToUnit = {}
+    local allUnits = _unitHelper.getUnits()
+    for _, unit in ipairs(allUnits) do
+        if unit.unitType ~= 'Infantry' and unit.unitType ~= 'Mech' and unit.unitType ~= 'Fighter' and unit.unitType ~= 'Space Dock' and unit.unitType ~= 'PDS' then --non-fighter ships only
+            if (unit.factionTokenName and unit.factionTokenName ~= factionTokenName) or (unit.color and unit.color ~= factionColor) then
+                opponentShipToPosition[unit.guid] = unit.position
+                unitGuidToUnit[unit.guid] = unit
+            end
+        end
+    end
+
+    local opponentShipGuidToHex = _systemHelper.hexesFromPositions(opponentShipToPosition)
+    local opponentShipToHex = {}
+    for guid, hex in pairs(opponentShipGuidToHex) do
+        opponentShipToHex[unitGuidToUnit[guid]] = opponentShipGuidToHex[guid]
+    end
+
+    local anyAnchoredShips = false
+    local systemToAnchoredShips = {}
+    for unit, hex in pairs(opponentShipToHex) do
+        local system = allHexesToSystemTiles[hex]
+        if system then
+            local systemShips = systemToAnchoredShips[system]
+            if not systemShips then
+                systemShips = {}
+                systemToAnchoredShips[system] = systemShips
+            end
+
+            table.insert(systemShips, unit)
+            anyAnchoredShips = true
+        end
+    end
+
+    if not anyAnchoredShips then
+        print('Dimensional Anchor: No non-fighter ships adjacent to Dimensional Tear systems. Won\'t use Hero Ability.')
+        return 1
+    end
+
+    -- Safe to commit to acting at this point, so purge the Hero card.
+    if owningObject.tag == 'Card' then
+        purgeCard(owningObject)
+    end
+
+    -- Function spawns dice for each ship, sets a dice cleanup on a 2 minute timeout,
+    -- and prints a guide for the dice color for auditability.
+    local function _prepareDice(systemToAnchoredShips)
+        -- Data and methods for dice handling copied from multiroller.
+
+        local dieType = "Die_10"
+        local removalDelay = 5
+        local radialOffset = 1.2
+        local heightOffset = 5
+        local dieSize = 1
+
+        --Finds a position, rotated around the Y axis, using distance you want + angle
+        --oPos is object pos, oRot=object rotation, distance = how far, angle = angle in degrees
+        local function _findGlobalPosWithLocalDirection(spawn_object, angle)
+            local object, distance = spawn_object, radialOffset * self.getScale().x
+            local oPos, oRot = object.getPosition(), object.getRotation()
+            local posX = oPos.x + math.sin( math.rad(angle+oRot.y) ) * distance
+            local posY = oPos.y + heightOffset
+            local posZ = oPos.z + math.cos( math.rad(angle+oRot.y) ) * distance
+            return {x=posX, y=posY, z=posZ}
+        end
+
+        --Gets a random rotation vector
+        local function _randomRotation()
+            --Credit for this function goes to Revinor (forums)
+            --Get 3 random numbers
+            local u1 = math.random();
+            local u2 = math.random();
+            local u3 = math.random();
+            --Convert them into quats to avoid gimbal lock
+            local u1sqrt = math.sqrt(u1);
+            local u1m1sqrt = math.sqrt(1-u1);
+            local qx = u1m1sqrt *math.sin(2*math.pi*u2);
+            local qy = u1m1sqrt *math.cos(2*math.pi*u2);
+            local qz = u1sqrt *math.sin(2*math.pi*u3);
+            local qw = u1sqrt *math.cos(2*math.pi*u3);
+            --Apply rotation
+            local ysqr = qy * qy;
+            local t0 = -2.0 * (ysqr + qz * qz) + 1.0;
+            local t1 = 2.0 * (qx * qy - qw * qz);
+            local t2 = -2.0 * (qx * qz + qw * qy);
+            local t3 = 2.0 * (qy * qz - qw * qx);
+            local t4 = -2.0 * (qx * qx + ysqr) + 1.0;
+            --Correct
+            if t2 > 1.0 then t2 = 1.0 end
+            if t2 < -1.0 then ts = -1.0 end
+            --Convert back to X/Y/Z
+            local xr = math.asin(t2);
+            local yr = math.atan2(t3, t4);
+            local zr = math.atan2(t1, t0);
+            --Return result
+            return {math.deg(xr),math.deg(yr),math.deg(zr)}
+        end
+
+        -- Use different color dice for manual auditability; copy from Multiroller
+        local unitTypeToDiceColor = {
+            ["Dreadnought"] = "Purple",
+            ["Flagship"] = "Black",
+            ["Destroyer"] = "Red",
+            ["War Sun"] = "Orange",
+            ["Carrier"] = "Blue",
+            ["Fighter"] = "Teal",
+            ["Infantry"] = "Green",
+            ["Cruiser"] = "Brown",
+            ["PDS"] = "Orange",
+            ["Space Dock"] = "Yellow",
+            ["Mech"] = "Pink"
+        }
+        
+        local diceToShip = {}
+        local unitTypesUsed = {}
+        _diceToBeRolled = {}
+
+        -- Spawn a die for each ship, around the system tile the ship is on.
+        for system, ships in pairs(systemToAnchoredShips) do
+            local shipCount = #ships
+            local angleStep = (360 / shipCount)
+
+            local systemObject = getObjectFromGUID(system.guid)
+
+            for i, ship in ipairs(ships) do
+                local die = spawnObject({
+                    type=dieType,
+                    position = _findGlobalPosWithLocalDirection(systemObject, angleStep*(i-1)),
+                    rotation = _randomRotation(), scale={dieSize,dieSize,dieSize}
+                })
+                die.setLock(true)
+                die.setColorTint(stringColorToRGB(unitTypeToDiceColor[ship.unitType]))
+
+                diceToShip[die] = ship
+                table.insert(_diceToBeRolled, die)
+                unitTypesUsed[ship.unitType] = true
+            end
+        end
+
+        -- Print guide showing the dice color for each ship.
+        print('DICE COLOR GUIDE')
+        for unitType, color in pairs(unitTypeToDiceColor) do
+            if unitTypesUsed[unitType] then
+                print('* ' .. unitType .. ': ' .. color)
+            end
+        end
+
+        -- Remove dice from board no matter what after 2 minutes
+        local function destroyDice()
+            for _, die in ipairs(_diceToBeRolled) do
+                if getObjectFromGUID(die.getGUID()) then
+                    destroyObject(die)
+                end
+            end
+            _diceToBeRolled = {}
+        end
+        Wait.time(destroyDice, 120)
+
+        return diceToShip
+    end
+
+    -- For each system, do rolls. Track results, print them by system+unitType.
+    -- eg. 'Bereg / Lirta IV: Cruiser has 1 capture (2#, 4, 9); Dreadnought has 0 captures (6).'
+    local diceToShip = _prepareDice(systemToAnchoredShips)
+
+    -- Start rolling dice.
+    -- Separate coroutine, so 'self' can animate hexes while the dice are being rolled.
+    startLuaCoroutine(self, 'dimensionalanchor_rollDiceCoroutine')
+
+    -- Function checks if dice are all still, and if they are maps their values to the ship they rolled for.
+    -- If dice are NOT still, just return an object with "waitingOnResults = true"
+    local function _processRollResults(diceToShip)
+        --wait for all dice to be settled
+        local allRest = true
+        for die, _ in pairs(diceToShip) do
+            if die ~= nil and die.resting == false then
+                allRest = false
+            end
+        end
+
+        if not allRest then
+            return { waitingOnResults = true }
+        end
+
+        local shipToResult = {}
+
+        for die, ship in pairs(diceToShip) do
+            local value = die.getValue()
+
+            shipToResult[ship] = value
+        end
+
+        return { waitingOnResults = false, shipToResult = shipToResult }
+    end
+
+    -- For blinking hexes.
+    -- blinkMode == 0: Set a highlight on hexes containing dimensional tear tokens
+    -- blinkMode == 1: Set a highlight only on hexes adjacent to dimensional tear tokens
+    -- blinkMode == 2: Do nothing (let highlights fade)
+    local function _setHexBlinkMode(dimTearHexToNeighboringHexes, allHexesToSystemTiles, blinkMode, blinkDuration)
+        if blinkMode > 1 then
+            return
+        end
+
+        if blinkMode == 0 then
+            for hex, _ in pairs(dimTearHexToNeighboringHexes) do
+                local system = allHexesToSystemTiles[hex]
+                if system and not system.hyperlane then
+                    local systemObject = assert(getObjectFromGUID(system.guid))
+                    systemObject.highlightOn(factionColor, blinkDuration)
+                end
+            end
+        end
+
+        if blinkMode == 1 then
+            for _, adjHexes in pairs(dimTearHexToNeighboringHexes) do
+                for _, hex in ipairs(adjHexes) do
+                    local system = allHexesToSystemTiles[hex]
+                    if system and not system.hyperlane then
+                        local systemObject = assert(getObjectFromGUID(system.guid))
+                        systemObject.highlightOn(factionColor, blinkDuration)
+                    end
+                end
+            end
+        end
+    end
+
+    -- Check for results,
+    -- and trigger system tile highlighting until results are ready
+    local rollResults = { waitingOnResults = true }
+    local rollTimeout = Time.time + 10
+    local rollMinimumWait = Time.time + 3
+    local blinkMode = 0 -- 0 = dim tear hexes; 1 = adj hexes; 2 = no hexes
+    local blinkTransitionTime = 0
+    while (rollResults.waitingOnResults or Time.time < rollMinimumWait) and Time.time < rollTimeout do
+        rollResults = _processRollResults(diceToShip)
+        coroutine.yield(0)
+
+        while blinkTransitionTime > Time.time do
+            coroutine.yield(0)
+        end
+
+        blinkMode = (blinkMode + 1) % 3
+        blinkTransitionTime = Time.time + 0.25 + (blinkMode == 2 and 0.25 or 0)
+        _setHexBlinkMode(hexToNeighboringHexes, allHexesToSystemTiles, blinkMode, 0.4)
+    end
+
+    -- Get results
+    local shipToResult = rollResults.shipToResult
+
+    -- Print results
+    for system, ships in pairs(systemToAnchoredShips) do
+        local unitTypeToResultRolls = {}
+
+        for _, ship in ipairs(ships) do
+            local resultsForType = unitTypeToResultRolls[ship.unitType]
+            if not resultsForType then
+                resultsForType = {}
+                local descriptiveUnitType = ship.unitType
+                if ship.factionTokenName then
+                    descriptiveUnitType = ship.factionTokenName .. '\'s ' .. descriptiveUnitType
+                elseif ship.color then
+                    descriptiveUnitType = ship.color .. ' ' .. descriptiveUnitType
+                end
+                unitTypeToResultRolls[descriptiveUnitType] = resultsForType
+            end
+
+            table.insert(resultsForType, assert(shipToResult[ship]))
+        end
+
+        print('Results for ' .. system.string .. ':')
+        for unitType, results in pairs(unitTypeToResultRolls) do
+            local resultString = ''
+            local first = true
+            for _, result in ipairs(results) do
+                if not first then
+                    resultString  = resultString .. ', '
+                end
+
+                resultString = resultString .. result
+                if result < 4 then
+                    resultString = resultString .. '#'
+                end
+
+                first = false
+            end
+
+            print('* ' .. unitType .. ': ' .. resultString)
+        end
+    end
+    
+    -- Create map of shipObject to the position it was in when it died.
+    -- Only includes ships whose roll was 1-3 (failing)
+    local shipObjectToDeathPosition = {}
+    for ship, result in pairs(shipToResult) do
+        if result < 4 then
+            local shipObject = getObjectFromGUID(ship.guid)
+            shipObjectToDeathPosition[shipObject] = shipObject.getPosition()
+        end
+    end
+
+    -- Loop and highlight dead ships until they're removed from their hex.
+    local anchoredUnitsUnmoved = true
+    local anchoredUnitsTimeout = Time.time + 120
+    while Time.time < anchoredUnitsTimeout and anchoredUnitsUnmoved do
+        anchoredUnitsUnmoved = false
+
+        local currentTileToDeathTile = {}
+        local shipStateToPosition = {}
+
+        -- Get ship current AND death position
+        for shipObject, deathPosition in pairs(shipObjectToDeathPosition) do
+            if getObjectFromGUID(shipObject.getGUID()) then -- is still on the board?
+                local currentPosition = shipObject.getPosition()
+                currentTileToDeathTile[currentPosition] = deathPosition
+                shipStateToPosition[shipObject.getGUID() .. '_cur'] = currentPosition
+                shipStateToPosition[shipObject.getGUID() .. '_death'] = deathPosition 
+            end
+        end
+
+        -- Use current and death positions to determine if the ship is in the same hex. If so, highlight ship.
+        local shipStateToHex = _systemHelper.hexesFromPositions(shipStateToPosition)
+        for shipObject, _ in pairs(shipObjectToDeathPosition) do
+            local currentHex = shipStateToHex[shipObject.getGUID() .. '_cur']
+            local deathHex = shipStateToHex[shipObject.getGUID() .. '_death']
+
+            if currentHex == deathHex then
+                anchoredUnitsUnmoved = true
+                shipObject.highlightOn(factionColor, 0.75)
+            end
+        end
+
+        -- Wait 2 seconds before repeating (1 sec on, 1 sec off)
+        local blinkWait = Time.time + 1.5
+        while Time.time < blinkWait do
+            coroutine.yield(0)
+        end
+    end
+
+    -- At this point, all dying ships have been handled. Destroy dice.
+    for _, die in ipairs(_diceToBeRolled) do
+        if getObjectFromGUID(die.getGUID()) then
+            destroyObject(die)
+        end
+    end
+    _diceToBeRolled = {}
+
+    return 1
+end
+
+function dimensionalanchor_rollDiceCoroutine()
+    assert(_diceToBeRolled and type(_diceToBeRolled) == 'table')
+
+    local waitToStart = Time.time + 1.5
+    while Time.time < waitToStart do
+        coroutine.yield(0)
+    end
+
+    for _, die in ipairs(_diceToBeRolled) do
+        die.setLock(false)
+        die.randomize()
+        local rollDelay = Time.time + 0.25
+        while Time.time < rollDelay do
+            coroutine.yield(0)
+        end
+    end
+
+    return 1
+end
+
+local function _carrionHeroAbility(owningObject, clickingColor) --Vuil'Raith Hero
+    if not _heroCardCanBeUsed(owningObject, clickingColor) then
+        -- Function will print why card cannot be used
+        return
+    end
+
+    table.insert(_carrionHeroAbilityOwningObjectQueue, owningObject)
+    startLuaCoroutine(self, '_carrionHeroAbilityCoroutine')
+end
+
+local function _applyContextMenuItems(card)
+    assert(card.tag == 'Card')
+
+    local factionCardAbilityFunc = _factionCardNameToAbilityFunc and _factionCardNameToAbilityFunc[card.getName()] or false
+
+    if factionCardAbilityFunc then
+        card.addContextMenuItem(factionCardAbilityFunc.name, function(clickingColor) factionCardAbilityFunc.method(card, clickingColor) end, false)
+    end
+
+    local colorToFactions = allFactions(false)
+    for _, faction in pairs(colorToFactions) do
+        if faction.hero == card.getName() then
+            -- Most heroes are manually handled, and even the automated ones could be manually handled.
+            -- Offer a simple Purge option on all faction hero cards.
+            card.addContextMenuItem("Purge", function(clickingColor) _purgeHeroCard(card, clickingColor) end, false)
+        end
+    end
+end
+
+function onObjectSpawn(object)
+    if object and object.tag == 'Card' then
+        _applyContextMenuItems(object)
+    end
+end
+
 function onLoad(saveState)
     self.setColorTint({ r = 0.25, g = 0.25, b = 0.25 })
     self.setScale({ x = 2, y = 0.01, z = 2 })
@@ -1146,6 +1847,20 @@ function onLoad(saveState)
     for factionName, attributes in pairs(_factionAttributes) do
         attributes.name = factionName
     end
+
+    _factionCardNameToAbilityFunc = {}
+    _factionCardNameToAbilityFunc['Jace X, 4th Air Legion'] = { name = 'Helio Cmd. Array', method = _jacexHeroAbility }
+    _factionCardNameToAbilityFunc['Conservator Procyon'] = { name = 'Multiverse Shift', method = _procynHeroAbility }
+    _factionCardNameToAbilityFunc['It Feeds on Carrion'] = { name = 'Dimensional Anchor', method = _carrionHeroAbility }
+    
+    local function delayedApplyContextMenuItems()
+        for _, object in ipairs(getAllObjects()) do
+            if object.tag == 'Card' then
+                _applyContextMenuItems(object)
+            end
+        end
+    end
+    Wait.frames(delayedApplyContextMenuItems, 7)
 end
 
 function onSave()

--- a/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
@@ -1181,6 +1181,18 @@ end
 
 -------------------------------------------------------------------------------
 
+local _animatingGuids = {}
+function onObjectPickUp(_, pickedUpObject)
+    assert(type(pickedUpObject) == 'userdata')
+
+    _animatingGuids[pickedUpObject.getGUID()] = nil
+end
+
+function onObjectDestroy(dyingObject)
+    _animatingGuids[dyingObject.getGUID()] = nil
+end
+
+
 local _purgeBagGuid = nil
 function getPurgeBag()
     local purgeBagObject = getObjectFromGUID(_purgeBagGuid)
@@ -1265,7 +1277,14 @@ local function _purgeHeroCard(owningObject, clickingColor)
     purgeCard(owningObject)
 end
 
-local function _jacexHeroAbility(owningObject, clickingColor) --Sol Hero
+-- Hero
+-- Faction: Federation of Sol
+-- Card Name: Jace X, 4th Air Legion
+-- Ability Name: Helio Command Array
+-- Ability Text:
+-- ACTION: Remove each of your command tokens from the game board
+-- and return them to your reinforcements. Then, purge this card.
+local function _jacexHeroAbility(owningObject, clickingColor)
     if not _heroCardCanBeUsed(owningObject, clickingColor) then
         -- Function will print why card cannot be used
         return
@@ -1320,24 +1339,25 @@ function _procynHeroAbilityCoroutine()
 
     --Map frontier tokens to system they're sitting on
     local frontierTokens = _exploreHelper.getAllFrontierTokens()
-    local frontierTokenToPosition = {}
+    local frontierTokenGuidToPosition = {}
     for _, token in ipairs(frontierTokens) do
-        frontierTokenToPosition[token] = token.getPosition()
+        frontierTokenGuidToPosition[token.getGUID()] = token.getPosition()
     end
+    coroutine.yield(0)
 
-    local frontierTokenToSystem = _systemHelper.systemsFromPositions(frontierTokenToPosition)
+    local frontierTokenGuidToSystem = _systemHelper.systemsFromPositions(frontierTokenGuidToPosition)
+    coroutine.yield(0)
 
     --Find all units
     local allUnits = _unitHelper.getUnits()
+    coroutine.yield(0)
 
     --Filter down to owning faction ships
     --NOTE: Can skip units lacking faction/color; they'll be alongside other units.
     local factionShipToPosition = {}
     for _, unit in ipairs(allUnits) do
         if unit.unitType ~= 'Infantry' and unit.unitType ~= 'Mech' and unit.unitType ~= 'Space Dock' and unit.unitType ~= 'PDS' then --ships only
-            if unit.factionTokenName and unit.factionTokenName == factionTokenName then
-                factionShipToPosition[unit.guid] = unit.position
-            elseif unit.color and unit.color == factionColor then
+            if (unit.factionTokenName and unit.factionTokenName == factionTokenName) or (unit.color and unit.color == factionColor) then
                 factionShipToPosition[unit.guid] = unit.position
             end
         end
@@ -1351,14 +1371,18 @@ function _procynHeroAbilityCoroutine()
             systemsWithFactionShipsSet[system.guid] = true
         end
     end
+    coroutine.yield(0)
 
     --For each system containing a frontier token AND owning faction ship, highlight the system tile
-    local explorableTokensToSystem = {}
+    local explorableTokenGuidToSystemGuid = {}
     local systemsToExplore = false
-    for token, system in pairs(frontierTokenToSystem) do
+    for tokenGuid, system in pairs(frontierTokenGuidToSystem) do
         if system and systemsWithFactionShipsSet[system.guid] then
-            explorableTokensToSystem[token] = system
+            explorableTokenGuidToSystemGuid[tokenGuid] = system.guid
             systemsToExplore = true
+
+            -- Blinking system tiles are tied to the frontier token, NOT the system tile object.
+            _animatingGuids[tokenGuid] = true
         end
     end
 
@@ -1366,13 +1390,14 @@ function _procynHeroAbilityCoroutine()
     local timeout = Time.time + 120
     while Time.time < timeout and systemsToExplore do
         systemsToExplore = false
-        for token, system in pairs(explorableTokensToSystem) do
+        for tokenGuid, systemGuid in pairs(explorableTokenGuidToSystemGuid) do
             -- See if token is still on table
-            if getObjectFromGUID(token.guid) then
-                local systemObject = getObjectFromGUID(system.guid)
-
+            local systemObject = getObjectFromGUID(systemGuid)
+            if systemObject and _animatingGuids[tokenGuid] and getObjectFromGUID(tokenGuid) then
                 systemObject.highlightOn(factionColor, 1)
                 systemsToExplore = true
+            elseif not systemObject or not getObjectFromGUID(tokenGuid) then
+                _animatingGuids[tokenGuid] = nil
             end
         end
 
@@ -1386,6 +1411,15 @@ function _procynHeroAbilityCoroutine()
     return 1
 end
 
+-- Hero
+-- Faction: The Empyrean
+-- Card Name: Conservator Procyon
+-- Ability Name: Multiverse Shift
+-- Ability Text:
+-- ACTION: Place 1 frontier token in each system that does not contain any
+-- planets and does not already have a frontier token. Then, explore each
+-- frontier token that is in a system that contains 1 or more of your ships.
+-- Then, purge this card.
 local function _procynHeroAbility(owningObject, clickingColor) --Empyrean Hero
     if not _heroCardCanBeUsed(owningObject, clickingColor) then
         -- Function will print why card cannot be used
@@ -1399,12 +1433,12 @@ end
 local _carrionHeroAbilityOwningObjectQueue = {}
 local _diceToBeRolled = {}
 function _carrionHeroAbilityCoroutine()
+    local owningObject = assert(table.remove(_carrionHeroAbilityOwningObjectQueue))
     if #_diceToBeRolled > 0 then
         print('Remove previously devoured ships before re-using Dimensional Anchor.')
         return 1
     end
-    local owningObject = assert(table.remove(_carrionHeroAbilityOwningObjectQueue))
-
+    
     --Find faction owning this hero ability (and it's color)
     local factionTokenName = false
     local factionColor = false
@@ -1427,6 +1461,7 @@ function _carrionHeroAbilityCoroutine()
             anyDimensionalTears = true
         end
     end
+    coroutine.yield(0)
 
     if not anyDimensionalTears then
         print('Dimensional Anchor: No Dimensional Tear tokens found on the table. Won\'t use Hero Ability.')
@@ -1456,6 +1491,8 @@ function _carrionHeroAbilityCoroutine()
         end
 
         hexToNeighboringHexes[hex] = neighboringHexes
+
+        coroutine.yield(0)
     end
 
     -- Get map of hex to system tile. Used to confirm a hex is actually placed on the table.
@@ -1470,29 +1507,24 @@ function _carrionHeroAbilityCoroutine()
 
     local allHexesToPosition = _systemHelper.hexesToPosition(allHexesAsMap)
     local allHexesToSystemTiles = _systemHelper.systemsFromPositions(allHexesToPosition)
+    coroutine.yield(0)
 
     --Find all units on those hexes
-    local opponentShipToPosition = {}
-    local unitGuidToUnit = {}
+    local opponentShipToHex = {}
+    local unitByGuid = {}
     local allUnits = _unitHelper.getUnits()
     for _, unit in ipairs(allUnits) do
         if unit.unitType ~= 'Infantry' and unit.unitType ~= 'Mech' and unit.unitType ~= 'Fighter' and unit.unitType ~= 'Space Dock' and unit.unitType ~= 'PDS' then --non-fighter ships only
             if (unit.factionTokenName and unit.factionTokenName ~= factionTokenName) or (unit.color and unit.color ~= factionColor) then
-                opponentShipToPosition[unit.guid] = unit.position
-                unitGuidToUnit[unit.guid] = unit
+                opponentShipToHex[unit.guid] = unit.hex
+                unitByGuid[unit.guid] = unit
             end
         end
     end
 
-    local opponentShipGuidToHex = _systemHelper.hexesFromPositions(opponentShipToPosition)
-    local opponentShipToHex = {}
-    for guid, hex in pairs(opponentShipGuidToHex) do
-        opponentShipToHex[unitGuidToUnit[guid]] = opponentShipGuidToHex[guid]
-    end
-
-    local anyAnchoredShips = false
+    local anchoredShipsCount = 0
     local systemToAnchoredShips = {}
-    for unit, hex in pairs(opponentShipToHex) do
+    for shipGuid, hex in pairs(opponentShipToHex) do
         local system = allHexesToSystemTiles[hex]
         if system then
             local systemShips = systemToAnchoredShips[system]
@@ -1501,12 +1533,12 @@ function _carrionHeroAbilityCoroutine()
                 systemToAnchoredShips[system] = systemShips
             end
 
-            table.insert(systemShips, unit)
-            anyAnchoredShips = true
+            table.insert(systemShips, shipGuid)
+            anchoredShipsCount = anchoredShipsCount + 1
         end
     end
 
-    if not anyAnchoredShips then
+    if anchoredShipsCount == 0 then
         print('Dimensional Anchor: No non-fighter ships adjacent to Dimensional Tear systems. Won\'t use Hero Ability.')
         return 1
     end
@@ -1597,17 +1629,21 @@ function _carrionHeroAbilityCoroutine()
             local systemObject = getObjectFromGUID(system.guid)
 
             for i, ship in ipairs(ships) do
-                local die = spawnObject({
+                local shipAttrs = unitByGuid[ship]
+
+                local dieObject = spawnObject({
                     type=dieType,
                     position = _findGlobalPosWithLocalDirection(systemObject, angleStep*(i-1)),
-                    rotation = _randomRotation(), scale={dieSize,dieSize,dieSize}
+                    rotation = _randomRotation(), scale={dieSize,dieSize,dieSize},
+                    callback_function = function(obj) --GUID is not available right away
+                        diceToShip[obj.getGUID()] = ship
+                        table.insert(_diceToBeRolled, obj.getGUID())
+                     end,
                 })
-                die.setLock(true)
-                die.setColorTint(stringColorToRGB(unitTypeToDiceColor[ship.unitType]))
+                dieObject.setLock(true)
+                dieObject.setColorTint(stringColorToRGB(unitTypeToDiceColor[shipAttrs.unitType]))
 
-                diceToShip[die] = ship
-                table.insert(_diceToBeRolled, die)
-                unitTypesUsed[ship.unitType] = true
+                unitTypesUsed[shipAttrs.unitType] = true
             end
         end
 
@@ -1622,8 +1658,9 @@ function _carrionHeroAbilityCoroutine()
         -- Remove dice from board no matter what after 2 minutes
         local function destroyDice()
             for _, die in ipairs(_diceToBeRolled) do
-                if getObjectFromGUID(die.getGUID()) then
-                    destroyObject(die)
+                local dieObject = getObjectFromGUID(die)
+                if dieObject then
+                    destroyObject(dieObject)
                 end
             end
             _diceToBeRolled = {}
@@ -1637,6 +1674,18 @@ function _carrionHeroAbilityCoroutine()
     -- eg. 'Bereg / Lirta IV: Cruiser has 1 capture (2#, 4, 9); Dreadnought has 0 captures (6).'
     local diceToShip = _prepareDice(systemToAnchoredShips)
 
+    -- Wait for all dice to spawn and receive a GUID
+    local diceToShipCount = 0
+    while diceToShipCount < anchoredShipsCount do
+        coroutine.yield(0)
+
+        diceToShipCount = 0
+        for die, _ in pairs(diceToShip) do
+            diceToShipCount = diceToShipCount + 1
+        end
+    end
+    
+
     -- Start rolling dice.
     -- Separate coroutine, so 'self' can animate hexes while the dice are being rolled.
     startLuaCoroutine(self, 'dimensionalanchor_rollDiceCoroutine')
@@ -1647,7 +1696,8 @@ function _carrionHeroAbilityCoroutine()
         --wait for all dice to be settled
         local allRest = true
         for die, _ in pairs(diceToShip) do
-            if die ~= nil and die.resting == false then
+            local dieObject = getObjectFromGUID(die)
+            if dieObject ~= nil and dieObject.resting == false then
                 allRest = false
             end
         end
@@ -1659,9 +1709,10 @@ function _carrionHeroAbilityCoroutine()
         local shipToResult = {}
 
         for die, ship in pairs(diceToShip) do
-            local value = die.getValue()
-
-            shipToResult[ship] = value
+            local dieObject = getObjectFromGUID(die)
+            if dieObject then
+                shipToResult[ship] = dieObject.getValue()
+            end
         end
 
         return { waitingOnResults = false, shipToResult = shipToResult }
@@ -1680,8 +1731,10 @@ function _carrionHeroAbilityCoroutine()
             for hex, _ in pairs(dimTearHexToNeighboringHexes) do
                 local system = allHexesToSystemTiles[hex]
                 if system and not system.hyperlane then
-                    local systemObject = assert(getObjectFromGUID(system.guid))
-                    systemObject.highlightOn(factionColor, blinkDuration)
+                    local systemObject = getObjectFromGUID(system.guid)
+                    if systemObject then
+                        systemObject.highlightOn(factionColor, blinkDuration)
+                    end
                 end
             end
         end
@@ -1691,8 +1744,10 @@ function _carrionHeroAbilityCoroutine()
                 for _, hex in ipairs(adjHexes) do
                     local system = allHexesToSystemTiles[hex]
                     if system and not system.hyperlane then
-                        local systemObject = assert(getObjectFromGUID(system.guid))
-                        systemObject.highlightOn(factionColor, blinkDuration)
+                        local systemObject = getObjectFromGUID(system.guid)
+                        if systemObject then
+                            systemObject.highlightOn(factionColor, blinkDuration)
+                        end
                     end
                 end
             end
@@ -1704,19 +1759,33 @@ function _carrionHeroAbilityCoroutine()
     local rollResults = { waitingOnResults = true }
     local rollTimeout = Time.time + 10
     local rollMinimumWait = Time.time + 3
-    local blinkMode = 0 -- 0 = dim tear hexes; 1 = adj hexes; 2 = no hexes
+    local blinkMode = 2 -- 0 = dim tear hexes; 1 = adj hexes; 2 = no hexes
     local blinkTransitionTime = 0
     while (rollResults.waitingOnResults or Time.time < rollMinimumWait) and Time.time < rollTimeout do
-        rollResults = _processRollResults(diceToShip)
-        coroutine.yield(0)
+        -- Animation 1: Alternating dimensional tear and adjacent hex blinking
+        --blinkMode = (blinkMode + 1) % 3
+        --blinkTransitionTime = Time.time + 0.25 + (blinkMode == 2 and 0.25 or 0)
+        --_setHexBlinkMode(hexToNeighboringHexes, allHexesToSystemTiles, blinkMode, 0.5)
+
+        -- Animation 2: Highlight all relevant hexes, then just the dimensional tear ones.
+        -- Gives the impression of ships being sucked towards the dimensional tears
+        blinkTransitionTime = Time.time + 1.5
+        _setHexBlinkMode(hexToNeighboringHexes, allHexesToSystemTiles, 0, 1)
+        _setHexBlinkMode(hexToNeighboringHexes, allHexesToSystemTiles, 1, 0.5)
+
+        -- Animation 3: Highlight all on, then all off. Simplest visually. Probably best from a gameplay
+        -- perspective and sticking to the "soul" of the physical game. But less cool, and less obvious why a
+        -- a system is adjacent when it's a random wormhole token or something across the board.
+        --blinkTransitionTime = Time.time + 2
+        --_setHexBlinkMode(hexToNeighboringHexes, allHexesToSystemTiles, 0, 1)
+        --_setHexBlinkMode(hexToNeighboringHexes, allHexesToSystemTiles, 1, 1)
 
         while blinkTransitionTime > Time.time do
             coroutine.yield(0)
         end
 
-        blinkMode = (blinkMode + 1) % 3
-        blinkTransitionTime = Time.time + 0.25 + (blinkMode == 2 and 0.25 or 0)
-        _setHexBlinkMode(hexToNeighboringHexes, allHexesToSystemTiles, blinkMode, 0.4)
+        rollResults = _processRollResults(diceToShip)
+        coroutine.yield(0)
     end
 
     -- Get results
@@ -1727,15 +1796,17 @@ function _carrionHeroAbilityCoroutine()
         local unitTypeToResultRolls = {}
 
         for _, ship in ipairs(ships) do
-            local resultsForType = unitTypeToResultRolls[ship.unitType]
+            local shipAttrs = assert(unitByGuid[ship])
+            local descriptiveUnitType = shipAttrs.unitType
+            if shipAttrs.factionTokenName then
+                descriptiveUnitType = shipAttrs.factionTokenName .. '\'s ' .. descriptiveUnitType
+            elseif shipAttrs.color then
+                descriptiveUnitType = shipAttrs.color .. ' ' .. descriptiveUnitType
+            end
+
+            local resultsForType = unitTypeToResultRolls[descriptiveUnitType]
             if not resultsForType then
                 resultsForType = {}
-                local descriptiveUnitType = ship.unitType
-                if ship.factionTokenName then
-                    descriptiveUnitType = ship.factionTokenName .. '\'s ' .. descriptiveUnitType
-                elseif ship.color then
-                    descriptiveUnitType = ship.color .. ' ' .. descriptiveUnitType
-                end
                 unitTypeToResultRolls[descriptiveUnitType] = resultsForType
             end
 
@@ -1763,13 +1834,16 @@ function _carrionHeroAbilityCoroutine()
         end
     end
     
-    -- Create map of shipObject to the position it was in when it died.
+    -- Create list of dying ships.
     -- Only includes ships whose roll was 1-3 (failing)
-    local shipObjectToDeathPosition = {}
+    local dyingShips = {}
     for ship, result in pairs(shipToResult) do
         if result < 4 then
-            local shipObject = getObjectFromGUID(ship.guid)
-            shipObjectToDeathPosition[shipObject] = shipObject.getPosition()
+            local shipObject = getObjectFromGUID(ship)
+            if shipObject then
+                table.insert(dyingShips, ship)
+                _animatingGuids[ship] = true
+            end
         end
     end
 
@@ -1782,25 +1856,15 @@ function _carrionHeroAbilityCoroutine()
         local currentTileToDeathTile = {}
         local shipStateToPosition = {}
 
-        -- Get ship current AND death position
-        for shipObject, deathPosition in pairs(shipObjectToDeathPosition) do
-            if getObjectFromGUID(shipObject.getGUID()) then -- is still on the board?
-                local currentPosition = shipObject.getPosition()
-                currentTileToDeathTile[currentPosition] = deathPosition
-                shipStateToPosition[shipObject.getGUID() .. '_cur'] = currentPosition
-                shipStateToPosition[shipObject.getGUID() .. '_death'] = deathPosition 
-            end
-        end
-
-        -- Use current and death positions to determine if the ship is in the same hex. If so, highlight ship.
-        local shipStateToHex = _systemHelper.hexesFromPositions(shipStateToPosition)
-        for shipObject, _ in pairs(shipObjectToDeathPosition) do
-            local currentHex = shipStateToHex[shipObject.getGUID() .. '_cur']
-            local deathHex = shipStateToHex[shipObject.getGUID() .. '_death']
-
-            if currentHex == deathHex then
-                anchoredUnitsUnmoved = true
-                shipObject.highlightOn(factionColor, 0.75)
+        for _, ship in ipairs(dyingShips) do
+            if _animatingGuids[ship] then
+                local shipObject = getObjectFromGUID(ship)
+                if shipObject then
+                    anchoredUnitsUnmoved = true
+                    shipObject.highlightOn(factionColor, 0.75)
+                else
+                    _animatingGuids[ship] = nil
+                end
             end
         end
 
@@ -1811,10 +1875,16 @@ function _carrionHeroAbilityCoroutine()
         end
     end
 
+    -- Stop tracking all GUIDs from this animation
+    for _, ship in ipairs(dyingShips) do
+        _animatingGuids[ship] = nil
+    end
+
     -- At this point, all dying ships have been handled. Destroy dice.
     for _, die in ipairs(_diceToBeRolled) do
-        if getObjectFromGUID(die.getGUID()) then
-            destroyObject(die)
+        local dieObject = getObjectFromGUID(die)
+        if dieObject then
+            destroyObject(dieObject)
         end
     end
     _diceToBeRolled = {}
@@ -1831,17 +1901,29 @@ function dimensionalanchor_rollDiceCoroutine()
     end
 
     for _, die in ipairs(_diceToBeRolled) do
-        die.setLock(false)
-        die.randomize()
-        local rollDelay = Time.time + 0.25
-        while Time.time < rollDelay do
-            coroutine.yield(0)
+        local dieObject = getObjectFromGUID(die)
+        if dieObject then
+            dieObject.setLock(false)
+            dieObject.randomize()
+            local rollDelay = Time.time + 0.25
+            while Time.time < rollDelay do
+                coroutine.yield(0)
+            end
         end
     end
 
     return 1
 end
 
+-- Hero
+-- Faction: The Vuil'Raith Cabal
+-- Card Name: It Feeds on Carrion
+-- Ability Name: Dimensional Anchor
+-- Ability Text:
+-- ACTION: Each other player rolls a die for each of their non-fighter ships
+-- that are in or adjacent to a system that contains a dimensional tear; on
+-- a 1-3, capture that unit. If this causes a player's ground forces or fighters
+-- to be removed, also capture those units. Then, purge this card.
 local function _carrionHeroAbility(owningObject, clickingColor) --Vuil'Raith Hero
     if not _heroCardCanBeUsed(owningObject, clickingColor) then
         -- Function will print why card cannot be used

--- a/Objects/TI4_Helpers/TI4_StrategyCardHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_StrategyCardHelper.ttslua
@@ -459,13 +459,20 @@ end
 
 -------------------------------------------------------------------------------
 
-function _returnCommandTokens()
+function _returnCommandTokens(factionTokenName)
+    assert(not factionTokenName or type(factionTokenName) == 'string')
+
     -- Precompute names for straight string equality checks.
     local tokenNameSet = {}
     local bagNameSet = {}
-    for _, faction in pairs(_factionHelper.allFactions()) do
-        tokenNameSet[faction.tokenName .. ' Command Token'] = true
-        bagNameSet[faction.tokenName .. ' Command Tokens Bag'] = true
+    if factionTokenName then
+        tokenNameSet[factionTokenName .. ' Command Token'] = true
+        bagNameSet[factionTokenName .. ' Command Tokens Bag'] = true
+    else
+        for _, faction in pairs(_factionHelper.allFactions()) do
+            tokenNameSet[faction.tokenName .. ' Command Token'] = true
+            bagNameSet[faction.tokenName .. ' Command Tokens Bag'] = true
+        end
     end
 
     local zoneExceptionObjectNameSet = {
@@ -518,12 +525,14 @@ function _returnCommandTokens()
     end
 
     -- Put tokens.
+    local putCount = 0
     for _, commandToken in ipairs(commandTokens) do
         local guid = commandToken.getGUID()
         local bag = tokenNameToBag[commandToken.getName()]
         if shouldPut(commandToken) and bag then
             _putTokenGuidSet[guid] = true
             bag.putObject(commandToken)
+            putCount = putCount + 1
         end
         coroutine.yield(0)
     end
@@ -540,7 +549,11 @@ function _returnCommandTokens()
     end
     _putTokenGuidSet = {}
 
-    broadcastToAll('Returned Command Tokens.')
+    if factionTokenName then
+        broadcastToAll('Returned ' .. putCount .. 'x ' .. factionTokenName .. ' Command Tokens.')
+    else
+        broadcastToAll('Returned Command Tokens.')
+    end
 end
 
 -------------------------------------------------------------------------------
@@ -839,6 +852,24 @@ end
 
 function endStatusPhase()
     startLuaCoroutine(self, '_endStatusPhaseCoroutine')
+end
+
+local _returnCommandTokensFactionQueue = {}
+
+function _returnCommandTokensForFactionCoroutine()
+    local factionTokenName = assert(table.remove(_returnCommandTokensFactionQueue))
+
+    _returnCommandTokens(factionTokenName)
+    coroutine.yield(0)
+
+    return 1
+end
+
+function returnCommandTokensForFaction(factionTokenName)
+    assert(type(factionTokenName) == 'string')
+
+    table.insert(_returnCommandTokensFactionQueue, factionTokenName)
+    startLuaCoroutine(self, '_returnCommandTokensForFactionCoroutine')
 end
 
 -------------------------------------------------------------------------------

--- a/Objects/TI4_Helpers/TI4_SystemHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_SystemHelper.ttslua
@@ -538,13 +538,52 @@ function systemFromPosition(position)
     end
 end
 
--- Get systems at positions
+-- Get systems at positions. Does NOT use ray-casting like "systemFromPosition".
 -- @param Map of arbitrary key to {xyz} position
 -- @return Map of same arbitrary key to system attributes or false
 function systemsFromPositions(keysToPositions)
+    assert(type(keysToPositions) == 'table')
+
+    -- Fill in extra system data
+    local systems = systems()
+
+    -- Get position of each system
+    local systemGuidToPosition = {}
+    for _, object in ipairs(getAllObjects()) do
+        local guid = object.getGUID()
+        if systems[guid] then
+            systemGuidToPosition[guid] = object.getPosition()
+        end
+    end
+
+    -- Get hex of each system
+    local systemGuidToHexes = hexesFromPositions(systemGuidToPosition)
+    -- Build reverse map (of system GUID to hex)
+    local systemHexToGuid = {}
+    for systemGuid, hex in pairs(systemGuidToHexes) do
+        if hex then
+            -- Warn (without failing) when a system already occupies this hex position (meaning the tiles are overlapping).
+            if systemHexToGuid[hex] then
+                print('WARNING: System tiles are overlapping at hex coordinate ' .. hex .. ' (' .. _systems[systemGuid].string .. ' and ' .. _systems[systemHexToGuid[hex]].string .. '). Some functions may be affected.')
+            else
+                systemHexToGuid[hex] = systemGuid
+            end
+        end
+    end
+
+    -- Get hex of each input key
+    local inputKeyToHexes = hexesFromPositions(keysToPositions)
+
+    -- Get system for each input key, using hex coordinate maps as a bridge
     local keysToSystems = {}
-    for key, position in pairs(keysToPositions) do
-        keysToSystems[key] = systemFromPosition(position) or false
+    for inputKey, hex in pairs(inputKeyToHexes) do
+        local systemGuid = systemHexToGuid[hex]
+
+        if systemGuid then
+            keysToSystems[inputKey] = assert(systems[systemGuid])
+        else
+            keysToSystems[inputKey] = false
+        end
     end
 
     return keysToSystems

--- a/Objects/TI4_Helpers/TI4_SystemHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_SystemHelper.ttslua
@@ -538,6 +538,18 @@ function systemFromPosition(position)
     end
 end
 
+-- Get systems at positions
+-- @param Map of arbitrary key to {xyz} position
+-- @return Map of same arbitrary key to system attributes or false
+function systemsFromPositions(keysToPositions)
+    local keysToSystems = {}
+    for key, position in pairs(keysToPositions) do
+        keysToSystems[key] = systemFromPosition(position) or false
+    end
+
+    return keysToSystems
+end
+
 --- Get system with the given tile number.
 -- @param tile (number).
 -- @return system table.
@@ -644,7 +656,9 @@ function wormholes(playerColor)
         ['Alpha Wormhole Token'] = { 'alpha' },
         ['Beta Wormhole Token'] = { 'beta' },
         ['Hil Colish'] = { 'delta' },
-        ['Gamma Wormhole Token'] = { 'gamma' },
+        ['Gamma Wormhole Token - Nexus Sovereignty'] = { 'gamma' },
+        ['Gamma Wormhole Token - Frontier'] = { 'gamma' },
+        ['Gamma Wormhole Token - Cultural'] = { 'gamma' },
     }
 
     for _, object in ipairs(getAllObjects()) do
@@ -666,7 +680,7 @@ function wormholes(playerColor)
                 end
             end
 
-            if name == 'Ion Storm Wormhole Token' then
+            if name == 'Ion Storm Token' then
                 local wormholeSide = 'alpha'
                 if object.is_face_down then
                     wormholeSide = 'beta'
@@ -1200,6 +1214,16 @@ function hexToPosition(hex)
     local x = (_M.f0 * q + _M.f1 * r) * _LAYOUT.size.x
     local z = (_M.f2 * q + _M.f3 * r) * _LAYOUT.size.z
     return { x = x + _LAYOUT.origin.x, y = 0, z = z + _LAYOUT.origin.z }
+end
+
+-- Bulk hexToPosition
+function hexesToPosition(guidToHex)
+    assert(type(guidToHex) == 'table')
+    local result = {}
+    for guid, hex in pairs(guidToHex) do
+        result[guid] = hexToPosition(hex)
+    end
+    return result
 end
 
 --- Get clockwise winding corners about a hex.

--- a/Objects/TI4_Map_Tool.ttslua
+++ b/Objects/TI4_Map_Tool.ttslua
@@ -41,6 +41,7 @@ end
 local _systemHelper = getHelperClient('TI4_SYSTEM_HELPER')
 local _zoneHelper = getHelperClient('TI4_ZONE_HELPER')
 local _deckHelper = getHelperClient('TI4_DECK_HELPER')
+local _exploreHelper = getHelperClient('TI4_EXPLORE_HELPER')
 
 local INPUT_LABEL_MAP_STRING = "Enter map string or press 'save' to save the current map"
 local SLICE_DATALABEL_NAME = "slice_data_label"
@@ -224,6 +225,15 @@ function createInputs()
         width          = buttonWidthMajor,
         height         = buttonHeightMajor,
         font_size      = fontSizeMajor,
+    })
+    self.createButton({
+        click_function = 'onButtonPlaceFrontier',
+        function_owner = self,
+        label          = 'Place\nFrontier Tokens',
+        position       = {x=majorX, y=buttonY, z=0.33},
+        width          = buttonWidthMajor,
+        height         = buttonHeightMajor,
+        font_size      = fontSizeMinor,
     })
     self.createButton({
         click_function = 'onButtonDrawLines',
@@ -686,7 +696,7 @@ function placeCardsCoroutine()
                 coroutine.yield(0)
             end
         else
-            broadcastToAll('Missing card for "' .. planet.name .. '"', 'Red')
+            broadcastToAll('Missing card for "' .. planetName .. '"', 'Red')
         end
     end
 
@@ -786,6 +796,9 @@ function returnCardsCoroutine()
         end
         coroutine.yield(0)
     end
+
+    _exploreHelper.retrieveFrontierTokens()
+    
     return 1
 end
 
@@ -1092,6 +1105,10 @@ function getSystemPositionsStartingAtOriginIterator(dy)
     local origin = { x = 0, y = getTableY() + (dy or 0), z = 0 }
     local rotation = { x = 0, y = 0, z = 0 }
     return spiral_hex_iterator(origin, rotation)
+end
+
+function onButtonPlaceFrontier()
+    _exploreHelper.placeFrontierTokens()
 end
 
 -------------------------------------------------------------------------------

--- a/Objects/TI4_RiftRoller.ttslua
+++ b/Objects/TI4_RiftRoller.ttslua
@@ -277,10 +277,10 @@ function findGlobalPosWithLocalDirection(spawn_object, angle)
     local posY = oPos.y + heightOffset
     local posZ = oPos.z + math.cos( math.rad(angle+oRot.y) ) * distance
     return {x=posX, y=posY, z=posZ}
-    end
+end
 
-    --Gets a random rotation vector
-    function randomRotation()
+--Gets a random rotation vector
+function randomRotation()
     --Credit for this function goes to Revinor (forums)
     --Get 3 random numbers
     local u1 = math.random();


### PR DESCRIPTION
Lots of changes to support Hero context-menu options. Specifically, handling the Sol, Empyrean and Vuil'Raith heroes (in a manner that is franken friendly). Also add generic "Purge" options to ALL heroes, for when they're manually handled.

The Vuil'Raith hero was originally just a bunch of dice rolls, but that felt chaotic and confusing having dice roll all over the board. I added some highlighting to try and make it more clear what was happening, but I'm not sure if it's clear/cool, or confusing/obnoxious...could use some feedback on that from a gameplay perspective. Can provide a save file to test with if interested.

Helper changes:
- Explore Helper exposes methods to:
  - Place Frontier Tokens on every empty system that doesn't already have one
  - Return all Frontier Tokens to the bag
  - Retrieve every Frontier Token object
- System Helper exposes methods to:
  - Bulk retrieve system attributes given a position (uses ray-casting)
  - Bulk retrieve positions from hexes
- Strategy Card Helper exposes method to return specific faction's command tokens

Major functional change, all in Faction Helper:
- OnLoad and OnObjectSpawn: Check if object is a Hero card, and context-menu options appropriately
- All Heroes get option to "Purge" the card. This is to support manual Hero ability handling.
- Sol Hero:
  - Use Strategy Card Helper to return all of the owning faction's command tokens
- Empyrean Hero:
  - Use Explore Helper to place Frontier Tokens in every system lacking a token
  - Map all units (of owning faction) to the system they're in, and if it's an empty system with a frontier token, then...
  - Use `highlightOn` to blink system tiles where the owning faction needs to explore a Frontier Token.
    - Note: We cannot explore automatically, because order of resolution matters.
- Vuil'Raith Hero:
  - Find all Dimensional Tear tokens, then the system they're in, and then also adjacent systems (accounting for wormholes)
  - Find all units that are from a different player than the ability-owner's faction
  - Filter units down to non-fighter ships in systems in/adjacent to Dimensional Tears
  - For each such unit: Spawn a die (copying methods from Rift Roller). Start a coroutine to roll the die over a few seconds.
  - While dice are rolling, wait for them to all have `.resting == true`.
    - While waiting, use `highlightOn` to blink systems that contain or are adjacent to Dimensional Tears.
  - Once all dice have come to rest, map the die values to the ship they were rolling for.
  - Print organized results to players.
  - For each ship that failed the roll, use `highlightOn` to make it blink until it's position is no longer in the hex that it died in.
    - We don't automate the capturing because there may be transported units that need to be organized.
    - Maybe we could clean up the ships anyway, then just blink the tiles that lost units for a few seconds so players can clean up transported units? Or something similar?
  - Once all ships are not in their death-hex anymore (or 2 minute timeout elapses), destroy all the dice. They stay on the table for a while for manual re-checking of the results.

Smaller changes:
- TI4 Map Tool: Button for placing frontier tokens, and retrieves tokens along with cards.
- Minor: Frontier tokens are put back in the bag upon exploring, not destroyed
- Minor: Make wormhole token names consistent with Explore Helper
- Minor: Arborec Hero name typo
- Minor: Spacing fix in Rift Roller