### PR TITLE
Explore Gamma Wormhole Tokens simplification

### DIFF
--- a/Objects/TI4_Helpers/TI4_ExploreHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_ExploreHelper.ttslua
@@ -203,8 +203,8 @@ function checkCardForToken(object_spawned, tileGUID, planetName)
     local systemList = _systemHelper.systems()
     local tokenList = attachmentCardToTokenMap[cardName]
     
-    local tokensToRetrieveSet = {}
     if tokenList then
+        local tokensToRetrieveSet = {}
         for _, item in ipairs(tokenList) do
             tokensToRetrieveSet[item] = true
         end

--- a/Objects/TI4_Helpers/TI4_ExploreHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_ExploreHelper.ttslua
@@ -14,8 +14,8 @@ local attachmentCardToTokenMap = {
     ["Paradise World"] = {"+2 Influence (Paradise World) Token"},
     ["Tomb of Emphidia"] = {"+1 Influence (Tomb of Emphidia) Token"},
     ["Demilitarized Zone"] = {"DMZ Token"},
-    ["Gamma Wormhole"] = {"Gamma Wormhole Token - Cultural"},
-    ["Gamma Relay"] = {"Gamma Wormhole Token - Frontier"},
+    ["Gamma Wormhole"] = {"Gamma Wormhole Token"},
+    ["Gamma Relay"] = {"Gamma Wormhole Token"},
     ["Mirage (Exploration)"] = {"Mirage Token", "Mirage", "Mirage Flight Academy"},
     ["Ion Storm"] = {"Ion Storm Token"},
 }
@@ -128,13 +128,21 @@ function explorePlanet(tileGUID, planetName)
             planetPos = planet.position
         end
     end
+    assert(planetTrait)
+
     deckType = traitMap[planetTrait]
 
-    local tile = getObjectFromGUID(tileGUID)
+    local tile = assert(getObjectFromGUID(tileGUID))
     local tilePos = tile.getPosition()
     local tileRot = tile.getRotation()
 
-    local exploreDeck = _deckHelper.getDeckWithReshuffle(deckType)
+    local exploreDeckGuid = _deckHelper.getDeckWithReshuffle(deckType)
+    if not exploreDeckGuid then
+        print('ERROR: Unable to locate ' .. deckType .. ' deck.')
+        return
+    end
+
+    local exploreDeck = assert(getObjectFromGUID(exploreDeckGuid))
 
     if exploreDeck.tag == 'Deck' then
         exploreDeck.takeObject({
@@ -194,27 +202,34 @@ function checkCardForToken(object_spawned, tileGUID, planetName)
     local cardName = object_spawned.getName()
     local systemList = _systemHelper.systems()
     local tokenList = attachmentCardToTokenMap[cardName]
+    
+    local tokensToRetrieveSet = {}
     if tokenList then
+        for _, item in ipairs(tokenList) do
+            tokensToRetrieveSet[item] = true
+        end
+
         local explorationBag = getObjectFromGUID(explorationBagGUID)
         local explorationBagContents = explorationBag.getObjects()
-        for _, item in ipairs(tokenList) do
-            for i, token in ipairs(explorationBagContents) do
-                if token.name == item then
-                    local objRot = object_spawned.getRotation()
-                    local techRot = 0
-                    if planetName then
-                        for _, planet in ipairs(systemList[tileGUID].planets) do
-                            if planet.name == planetName then
-                                if planet.tech ~= nil then techRot = 180 end
-                            end
+        for _, token in ipairs(explorationBagContents) do
+            if tokensToRetrieveSet[token.name] then
+                local objRot = object_spawned.getRotation()
+                local techRot = 0
+                if planetName then
+                    for _, planet in ipairs(systemList[tileGUID].planets) do
+                        if planet.name == planetName then
+                            if planet.tech ~= nil then techRot = 180 end
                         end
                     end
-                    explorationBag.takeObject({
-                        position = object_spawned.getPosition(),
-                        rotation = {objRot.x, objRot.y, techRot},
-                        guid = token.guid,
-                    })
                 end
+                explorationBag.takeObject({
+                    position = object_spawned.getPosition(),
+                    rotation = {objRot.x, objRot.y, techRot},
+                    guid = token.guid,
+                })
+
+                -- Only get each token once.
+                tokensToRetrieveSet[token.name] = nil
             end
         end
     end

--- a/Objects/TI4_Helpers/TI4_SystemHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_SystemHelper.ttslua
@@ -695,9 +695,7 @@ function wormholes(playerColor)
         ['Alpha Wormhole Token'] = { 'alpha' },
         ['Beta Wormhole Token'] = { 'beta' },
         ['Hil Colish'] = { 'delta' },
-        ['Gamma Wormhole Token - Nexus Sovereignty'] = { 'gamma' },
-        ['Gamma Wormhole Token - Frontier'] = { 'gamma' },
-        ['Gamma Wormhole Token - Cultural'] = { 'gamma' },
+        ['Gamma Wormhole Token'] = { 'gamma' },
     }
 
     for _, object in ipairs(getAllObjects()) do

--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -865,7 +865,7 @@ local _unitModifiers = {
         description = '+1 die to a unit ability (anti-fighter barrage, bombardment, space cannon)',
         owner = OWNER.SELF,
         type = TYPE.CHOOSE,
-        excludeFaction = 'The Nomad',
+        excludeFaction = 'The Argent Flight',
         apply = function(unitAttrs, params)
             best = false
             for unitType, attr in pairs(unitAttrs) do
@@ -965,7 +965,7 @@ local _unitModifiers = {
         description = 'One non-fighter ship gains the SUSTAIN DAMAGE, combat value, and ANTI-FIGHTER BARRAGE of the Nomad flagship (this modifier adds a new unit for AFB/space combat, remove the affected unit from normal setup)',
         owner = OWNER.SELF,
         type = TYPE.MUTATE,
-        excludeFaction = 'The Argent Flight',
+        excludeFaction = 'The Nomad',
         apply = function(unitAttrs, params)
             unitAttrs['The Cavalry'] = {
                 antiFighterBarrage = { hit = 8, dice = 3 },


### PR DESCRIPTION
All Gamma Wormhole Tokens share the same name now. So players that are manually moving tokens in/out of bags don't need to pick the right one. The Explore Helper only grabs the first token it finds for each one on it's list, rather than all tokens with the correct name.

Bonus: Fix the faction names on two unit modifiers