### PR TITLE
The Cavalry fixes; Strike Wing Alpha II support; reroll dice ability support

### DIFF
--- a/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_UnitHelper.ttslua
@@ -172,7 +172,7 @@ local _unitOverrides = {
     ['Super-Dreadnought II'] = { upgrade = 'Dreadnought', bombardment = { dice = 1, hit = 4 }, spaceCombat = { hit = 4 }, move = 2, capacity = 2 },
     -- PoK faction unit overrides and upgrades
     ['Strike Wing Alpha I'] = { override = 'Destroyer', spaceCombat = { hit = 8 }, capacity = 1 },
-    ['Strike Wing Alpha II'] = { upgrade = 'Destroyer', antiFighterBarrage = { dice = 3, hit = 6 }, spaceCombat = { hit = 7 }, capacity = 1 },
+    ['Strike Wing Alpha II'] = { upgrade = 'Destroyer', antiFighterBarrage = { dice = 3, hit = 6, extraHitsOn = { value = 9, message = '${PlayerName} destroys ${ExtraHits} of the opponent\'s Infantry in the space area.' } }, spaceCombat = { hit = 7 }, capacity = 1 },
     ['Crimson Legionnaire I'] = { override = 'Infantry', groundCombat = { hit = 8 } },
     ['Crimson Legionnaire II'] = { upgrade = 'Infantry', groundCombat = { hit = 7 } },
     ['Saturn Engine I'] = { override = 'Cruiser', spaceCombat = { hit = 7 }, capacity = 1 },
@@ -569,7 +569,9 @@ local _unitModifiers = {
         apply = function(unitAttrs, params)
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.groundCombat and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.groundCombat and unitCount > 0 then
                     if (not best) or attr.groundCombat.hit < best.groundCombat.hit then
                         best = attr
                     end
@@ -763,7 +765,9 @@ local _unitModifiers = {
         apply = function(unitAttrs, params)
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.spaceCannon and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.spaceCannon and unitCount > 0 then
                     if (not best) or attr.spaceCannon.hit < best.spaceCannon.hit then
                         best = attr
                     end
@@ -774,7 +778,9 @@ local _unitModifiers = {
             end
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.bombardment and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.bombardment and unitCount > 0 then
                     if (not best) or attr.bombardment.hit < best.bombardment.hit then
                         best = attr
                     end
@@ -867,9 +873,11 @@ local _unitModifiers = {
         type = TYPE.CHOOSE,
         excludeFaction = 'The Argent Flight',
         apply = function(unitAttrs, params)
-            best = false
+            local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.antiFighterBarrage and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.antiFighterBarrage and unitCount > 0 then
                     if (not best) or (attr.antiFighterBarrage.hit < best.antiFighterBarrage.hit) then
                         best = attr
                     end
@@ -878,9 +886,11 @@ local _unitModifiers = {
             if best then
                 best.antiFighterBarrage.extraDice = (best.antiFighterBarrage.extraDice or 0) + 1
             end
-            best = false
+            local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.bombardment and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.bombardment and unitCount > 0 then
                     if (not best) or (attr.bombardment.hit < best.bombardment.hit) then
                         best = attr
                     end
@@ -889,9 +899,11 @@ local _unitModifiers = {
             if best then
                 best.bombardment.extraDice = (best.bombardment.extraDice or 0) + 1
             end
-            best = false
+            local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.spaceCannon and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.spaceCannon and unitCount > 0 then
                     if (not best) or (attr.spaceCannon.hit < best.spaceCannon.hit) then
                         best = attr
                     end
@@ -915,6 +927,27 @@ local _unitModifiers = {
                 end
                 if attr.groundCombat then
                     attr.groundCombat.hit = attr.groundCombat.hit - 1
+                end
+            end
+        end
+    },
+
+    ['Ta Zern'] = {
+        description = 'You may reroll any dice. (When active will reroll all misses)',
+        leader = LEADER.COMMANDER,
+        owner = OWNER.SELF,
+        type = TYPE.ADJUST,
+        toggleActive = true,
+        apply = function(unitAttrs)
+            for unitType, attr in pairs(unitAttrs) do
+                if attr.spaceCannon then
+                    attr.spaceCannon.rerollMisses = true
+                end
+                if attr.bombardment then
+                    attr.bombardment.rerollMisses = true
+                end
+                if attr.antiFighterBarrage then
+                    attr.antiFighterBarrage.rerollMisses = true
                 end
             end
         end
@@ -1010,36 +1043,42 @@ local _unitModifiers = {
         apply = function(unitAttrs, params)
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.antiFighterBarrage and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.antiFighterBarrage and unitCount > 0 then
                     if (not best) or (attr.antiFighterBarrage.hit < best.antiFighterBarrage.hit) then
                         best = attr
                     end
                 end
-                if best then
-                    best.antiFighterBarrage.extraDice = (best.antiFighterBarrage.extraDice or 0) + 1
-                end
+            end
+            if best then
+                best.antiFighterBarrage.extraDice = (best.antiFighterBarrage.extraDice or 0) + 1
             end
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.bombardment and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.bombardment and unitCount > 0 then
                     if (not best) or (attr.bombardment.hit < best.bombardment.hit) then
                         best = attr
                     end
                 end
-                if best then
-                    best.bombardment.extraDice = (best.bombardment.extraDice or 0) + 1
-                end
+            end
+            if best then
+                best.bombardment.extraDice = (best.bombardment.extraDice or 0) + 1
             end
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.spaceCannon and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.spaceCannon and unitCount > 0 then
                     if (not best) or (attr.spaceCannon.hit < best.spaceCannon.hit) then
                         best = attr
                     end
                 end
-                if best then
-                    best.spaceCannon.extraDice = (best.spaceCannon.extraDice or 0) + 1
-                end
+            end
+            if best then
+                best.spaceCannon.extraDice = (best.spaceCannon.extraDice or 0) + 1
             end
         end
     },
@@ -1069,7 +1108,9 @@ local _unitModifiers = {
         apply = function(unitAttrs, params)
             local best = false
             for unitType, attr in pairs(unitAttrs) do
-                if attr.spaceCombat and (params.myUnitTypeToCount[unitType] or 0) > 0 then
+                -- Check for units present, then check for dynamically injected units, then default to 0
+                local unitCount = params.myUnitTypeToCount[unitType] or attr.unitCount or 0
+                if attr.spaceCombat and unitCount > 0 then
                     if (not best) or (attr.spaceCombat.hit < best.spaceCombat.hit) then
                         best = attr
                     end
@@ -1378,9 +1419,17 @@ function getColorToUnitModifiers()
 
     -- Add commanders (including Alliance and Imperia sharing).
     local colorToCommanders = _factionHelper.getColorToCommanders()
+    local toggleActiveCommanderToColor = {}
     for color, commanders in pairs(colorToCommanders) do
         for _, commander in ipairs(commanders) do
-            addModifier(color, commander)
+            local unitModifier = _unitModifiers[commander]
+            if not unitModifier or not unitModifier.toggleActive then
+                addModifier(color, commander)
+            else
+                -- Toggle Active commanders require additional checks
+                toggleActiveCommanderToColor[commander] = toggleActiveCommanderToColor[commander] or {}
+                table.insert(toggleActiveCommanderToColor[commander], color)
+            end
         end
     end
 
@@ -1456,6 +1505,15 @@ function getColorToUnitModifiers()
                 local color = _zoneHelper.zoneFromPosition(object.getPosition())
                 if sardakk and sardakk.color and sardakk.color ~= color then
                     addModifier(sardakk.color, name)
+                end
+            end
+
+            local commanderColors = toggleActiveCommanderToColor[name]
+            if commanderColors then
+                -- This object has passed any 'toggle active' checks. Add commander to specified colors.
+                -- These come from faction.commander, Alliance promissory notes, and Imperia
+                for _, color in ipairs(commanderColors) do
+                    addModifier(color, name)
                 end
             end
 

--- a/Objects/TI4_MultiRoller_Plat.ttslua
+++ b/Objects/TI4_MultiRoller_Plat.ttslua
@@ -761,8 +761,20 @@ end
 
 function setUnitCount(unit, count)
     assert(type(unit) == 'string' and type(count) == 'number')
-    self.UI.setValue(unit .. ".unitCount", count)
-    _unitTypeToCount[unit] = count
+
+    -- Restrict to allowable unit types
+    -- Non-basic unit types may be dynamically injected;
+    -- we don't want to keep (and subsequently override)
+    -- any dynamic state. So when setting up a roll from
+    -- the "inject" method, ensure we are only tracking
+    -- the known unit types.
+    for _, unitType in ipairs(UNIT_TYPES) do
+        if unitType == unit then
+            self.UI.setValue(unit .. ".unitCount", count)
+            _unitTypeToCount[unit] = count
+            return
+        end
+    end
 end
 
 function getUnitCount(unit)
@@ -1049,7 +1061,7 @@ function Roller_RollDiceCoroutine()
     -- Wait for dice, extract roll values.
     local timeout = Time.time + 3
     for _, dice in ipairs(Roller._dice) do
-        dice._rollValues = {}
+        dice._rollData = {}
         for _, guid in ipairs(dice._guids) do
             local die = false
             while true do
@@ -1061,14 +1073,73 @@ function Roller_RollDiceCoroutine()
                 end
             end
             if die then
-                table.insert(dice._rollValues, die.getValue() or 0)
+                local rollData = { guid = guid, finalValue = die.getValue() or 0 }
+                table.insert(dice._rollData, rollData)
                 die.interactable = true
             end
         end
     end
     coroutine.yield(0)
 
+    -- Find dice that reroll-on-miss, and prep them for reroll.
+    local conductRerolls = false
+    for _, dice in ipairs(Roller._dice) do
+        local rerollMisses = dice.rerollMisses or false
+        if rerollMisses then
+            dice._rerollGuids = {}
+            for _, rollData in ipairs(dice._rollData) do
+                local guid = rollData.guid
+                local origValue = rollData.finalValue
+
+                -- Track dice GUID for reroll
+                -- Set the die's "initial roll" value, unset it's "final roll" value
+                if origValue < dice.hitValue then
+                    table.insert(dice._rerollGuids, guid)
+                    rollData.origValue = origValue
+                    rollData.finalValue = false
+                    conductRerolls = true
+                end
+            end
+        end
+    end
+
+    -- For any rerolls found, roll the dice! And watch for results.
+    if conductRerolls then
+        -- Roll dice in _rerollGuids
+        for _, dice in ipairs(Roller._dice) do
+            for _, guid in ipairs(dice._rerollGuids or {}) do
+                local die = getObjectFromGUID(guid)
+                die.interactable = false
+                die.roll()
+            end
+        end
+        coroutine.yield(0)
+
+        -- Watch ALL dice, and update the 'final value' 
+        local timeout = Time.time + 3
+        for _, dice in ipairs(Roller._dice) do
+            for _, rollData in ipairs(dice._rollData) do
+                local die = false
+                while true do
+                    die = getObjectFromGUID(rollData.guid)  -- re-get every time, can be deleted
+                    if die and (not die.resting) and Time.time < timeout then
+                        coroutine.yield(0)
+                    else
+                        break
+                    end
+                end
+                -- If we have a die, but not a final result, set the final result
+                if die and not rollData.finalValue then
+                    rollData.finalValue = die.getValue() or 0
+                    die.interactable = true
+                end
+            end
+        end
+        coroutine.yield(0)
+    end
+
     -- Generate report.
+    local specialMessages = {}
     local message = {}
     local hits = 0
     for _, dice in ipairs(Roller._dice) do
@@ -1079,28 +1150,49 @@ function Roller_RollDiceCoroutine()
         item = item .. ']: '
 
         local rollValues = {}
+        local critCount = 0
         local unitHitCount = 0
-        for _, rollValue in ipairs(dice._rollValues) do
+        for i, rollData in ipairs(dice._rollData) do
+            local rollValue = rollData.finalValue
+            local prefix = ''
             local suffix = ''
             if rollValue >= dice.hitValue then
                 hits = hits + 1
                 unitHitCount = unitHitCount + 1
                 suffix = '#'
             end
-            if dice.critCount and dice.critValue and (rollValue >= dice.critValue) then
-                hits = hits + dice.critCount
-                unitHitCount = unitHitCount + dice.critCount
-                for _ = 1, dice.critCount do
-                    suffix = suffix .. '#'
+            if (dice.critCount or dice.critMessage) and dice.critValue and (rollValue >= dice.critValue) then
+                if dice.critCount then
+                    hits = hits + dice.critCount
+                    unitHitCount = unitHitCount + dice.critCount
+                    for _ = 1, dice.critCount do
+                        suffix = suffix .. '#'
+                    end
+                end
+                if dice.critMessage then
+                    critCount = critCount + 1
                 end
             end
-            table.insert(rollValues, rollValue .. suffix)
+            if dice.rerollMisses and rollData.origValue then
+                local originalRollValue = rollData.origValue
+                prefix = originalRollValue .. '->'
+            end
+            table.insert(rollValues, prefix .. rollValue .. suffix)
             setHitCount(dice.unitId, unitHitCount)
         end
+
         table.insert(message, dice.unitName .. ' ' .. item .. table.concat(rollValues, ', '))
+
+        if critCount > 0 and dice.critMessage then
+            local critMessage = dice.critMessage:gsub('%${PlayerName}', playerName):gsub('%${ExtraHits}', critCount)
+            table.insert(specialMessages, critMessage)
+        end
     end
     broadcastToAll(playerName .. ' rolled: [ffffff]' .. table.concat(message, ', '), playerColor)
     broadcastToAll(playerName .. ' landed ' .. hits .. ' hit' .. (hits == 1 and '' or 's') .. '.', playerColor)
+    for _, message in ipairs(specialMessages) do
+        broadcastToAll(message, playerColor)
+    end
 
     Roller._setRollInProgress(false)
     return 1
@@ -1139,6 +1231,8 @@ function rollDiceForAbility(player, ability)
                 hitValue = abilityAttrs.hit,
                 critCount = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.count,
                 critValue = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.value,
+                critMessage = abilityAttrs.extraHitsOn and abilityAttrs.extraHitsOn.message,
+                rerollMisses = abilityAttrs.rerollMisses,
                 unitName = unit_stats.name,
                 unitId = unit_id
             })


### PR DESCRIPTION
This PR covers all of the following:
- CHOOSE abilities detect dynamically injected units, like The Cavalry. Works by also checking the `unitCount` field on the `unitAttributes` object (if myUnitTypeToCount has no entry for the type).
- Minor: Strike Wing Ambuscade uses `local best = false` instead of `best = false` for consistency
- Argent Flight commander "Trrakan Aun Zulok": Fix the placement of the `if best then [...]` checks to assign extra dice correctly
- Added Universities of Jol-Nar commander "Ta Zern": Sets `rerollMisses = true` on relevant ability types for all units.
- Strike Alpha II unit upgrade: Has a "crit message". New feature described below.
  - Ex msg: "Flakey destroys 1 of the opponent's Infantry in the space area."
- Multiroller changes
  - When setting unit counts, only set counts for known unit types. Otherwise, dynamically injected unit types will have a count of 0, and that 0 will override the actual count for that unit type.
  - New crit functionality: Crit Message. In addition to increasing the final hit count, crits can also have an additional message displayed, using the number of critical hits. This allows Strike Wing Alpha II to display how many infantry are destroyed by rolls of 9-10.
  - New reroll functionality: Units whose ability has `rerollMisses == true` will now see all dice below the hit threshold rolled a second time.
    - Is reported with "{firstRoll}->{reroll}". For example: "Flakey rolled: Destroyer [HIT:9]: 10#, 3->7, 2->2, 6->9#"