### PR TITLE
Mirage decal applied to arena on activation

### DIFF
--- a/Objects/AutoFillMultiRollerArena.ttslua
+++ b/Objects/AutoFillMultiRollerArena.ttslua
@@ -40,6 +40,24 @@ function onPlayerTurnEnd(player_color_end, player_color_next)
     _activeSystemGuid = false
 end
 
+function _applyPlanetDecals(system)
+    local decals = {}
+
+    for _, planet in ipairs(system.planets or {}) do
+        if planet.planetDecal then
+            table.insert(decals, {
+                name = planet.name .. ' decal',
+                url = planet.planetDecal,
+                position = { x = planet.position.x, y = 0.1, z = planet.position.z },
+                rotation = { x = 90, y = 180, z = 0 },
+                scale = { x = 2.3, y = 2.3, z = 1 }, -- TODO: rework Mirage image so this can be 1,1,1
+            })
+        end
+    end
+
+    self.setDecals(decals)
+end
+
 function onSystemActivation(system)
     if _activeSystemGuid == system.guid then
         return
@@ -51,6 +69,8 @@ function onSystemActivation(system)
     local systemCustom = systemObject.getCustomObject()
     local custom = self.getCustomObject()
     custom.diffuse = systemCustom.diffuse
+
+    _applyPlanetDecals(system, systemObject)
 
     -- Resetting custom object triggers delete.  Tell Deleted Items it is ok.
     ignoreDeletedItem(self.getGUID())

--- a/Objects/TI4_Helpers/TI4_ExploreHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_ExploreHelper.ttslua
@@ -130,7 +130,8 @@ local MIRAGE_PLANET = {
     influence = 2,
     trait = 'cultural',
     legendary = true,
-    legendaryCard = 'Mirage Flight Acadamy'
+    legendaryCard = 'Mirage Flight Acadamy',
+    planetDecal = 'http://cloud-3.steamusercontent.com/ugc/1655600739160551828/A3FEA7A2A7275F196BB7E7E071C79E8B71015503/'
 }
 
 -------------------------------------------------------------------------------

--- a/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_FactionHelper.ttslua
@@ -1235,7 +1235,6 @@ function purgeCard(cardObject)
     --TODO: Maybe deck related stuff? Object deletion checks? Card locked stuff?
 
     purgeBagObject.putObject(cardObject)
-    broadcastToAll('PURGING card \'' .. cardObject.getName() .. '\'')
 end
 
 local function _heroCardCanBeUsed(cardObject, usingColor)
@@ -1466,8 +1465,8 @@ function _carrionHeroAbilityCoroutine()
     end
     assert(factionTokenName and factionColor, 'Dimensional Anchor: Trying to invoke Hero Ability, but no faction with "It Feeds on Carrion" is at the table.')
 
-    --Find each dimensional tear token
-    local dimensionalTearName = "Vuil'raith Cabal Gravity Rift Token"
+    --Find each dimensional tear token (Cabal only)
+    local dimensionalTearName = "Tear Token (Cabal)"
     local dimTokenToPosition = {}
     local anyDimensionalTears = false
     for _, object in ipairs(getAllObjects()) do


### PR DESCRIPTION
Quick and simple Mirage decal applied to the Multiroller Arena on activation

I made the Mirage image to have a transparent background. Image and GIMP files attached. Currently the URL points to the image in my own Steam cloud.
[Mirage Token Transparent.zip](https://github.com/darrellanderson/CrLua/files/5692923/Mirage.Token.Transparent.zip)

Also threw in minor bug fix for Vuil'Raith Hero.