### PR TITLE
adjust sheet placement and snap points

### DIFF
--- a/Objects/TI4_Helpers/TI4_SetupHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_SetupHelper.ttslua
@@ -117,9 +117,9 @@ local SetupColor = {
     NAME_TO_PLAYER_ZONE_OFFSET = {
         ['Notes %($COLOR%)'] = { x = 7, z = 2 },
         ['Active/Passed %($COLOR%)'] = { x = 4, y = 1, z = 2, flip = false },  -- do not flip, changing setup can lead to unflipped tokens
-        ['Command Sheet %($COLOR%)'] = { x = -8.5, z = 11, lock = true },
+        ['Command Sheet %($COLOR%)'] = { x = -8.2, z = 11, lock = true },
         ['Directionaliser %($COLOR%)'] = { x = 0, y = 0, z = -2, yRot = 270, lock = true },
-        ['Leader Sheet %($COLOR%)'] = { x = 8.8, z = 11, lock = true },
+        ['Leader Sheet %($COLOR%)'] = { x = 8.45, z = 11, lock = true },
     },
     NAME_TO_PLAYER_AGENDA_ZONE_OFFSET = {
         ['$COLOR Player Votes'] = { x = 0, y = 1, z = 1, yRot = 180 },
@@ -1645,10 +1645,13 @@ end
 function SetupFaction.addFactionSheetUnitUpgradeSnapPoints(factionSheet)
     assert(type(factionSheet) == 'userdata')
 
-    local x0 = 1.09
-    local dx = (-1.09 * 2) / 3
-    local z0 = -0.74
-    local dz = (0.74 * 2) / 3
+    local x0 = 1.100277662
+    local z0 = -0.73410183
+    local x3 = -1.07248139
+    local z3 = 0.734419465
+
+    local dx = (x3 - x0) / 3
+    local dz = (z3 - z0) / 3
 
     local snapPoints = {}
     for col = 0, 3 do


### PR DESCRIPTION
These changes are intended to be applied with additional steps described below.

The goal is to change faction+leader sheet sizes so that the cards cleanly cover their intended slot (unit upgrades on the faction sheet, leaders+mech on the leader sheet).

Updated unit upgrade snap points can be used on their own without any other changes, though the cards will be too small. Updated sheet positions should only be applied if object resizing described below is also applied.

## Post-Merge Steps

1) Unpack and unlock all Leader and Command sheets
2) Hover over each Leader sheet and tap '-' twice.
    - The goal is to reduce scale to approximately: `x=0.95 y=0.95 z=0.95`
3) Hover each Command sheet and tap '-' twice.
    - The approximate scale we're aiming for is: `x=1.3275 y=0.094827 z=1.3275`
4) Repack Command+Leader sheets
5) Pull out every Faction sheet (including homebrew and other content)
6) Hover over each Faction sheet and tap '-' **three** (3) times
    - There are a lot of these. Maybe it would be easier to modify the save directly?
    - The exact scale to set is `x=4.4359 y=1 z=4.4359`
7) Repack all Faction sheets
8) Use the Setup tool to rearrange Command/Leader sheets into new positions from this PR (by right-clicking on "Setup")

Here is the outcome of applying these changes. Note the fit of unit upgrades in the upper-left and bottom-right slots.
![sheets-resized](https://user-images.githubusercontent.com/2775535/102221876-b2cede00-3eb0-11eb-84e0-3e7781e76819.png)