### PR TITLE
move relic fragments that are placed in the general purge bag

### DIFF
--- a/Objects/TI4_PurgeBag.ttslua
+++ b/Objects/TI4_PurgeBag.ttslua
@@ -16,7 +16,8 @@ function _getByName(name, tag)
             return object
         end
     end
-    error('_getByName: missing "' .. name .. '"')
+    
+    return false
 end
 
 function getRelicFragmentType(object)

--- a/Objects/TI4_PurgeBag.ttslua
+++ b/Objects/TI4_PurgeBag.ttslua
@@ -3,14 +3,60 @@
 -- @author Jabberwocky
 --
 
+local _getByNameCache = {}
+function _getByName(name, tag)
+    local guid = _getByNameCache[name]
+    local object = guid and getObjectFromGUID(guid)
+    if object and ((not tag) or object.tag == tag) then
+        return object
+    end
+    for _, object in ipairs(getAllObjects()) do
+        if object.getName() == name and ((not tag) or object.tag == tag) then
+            _getByNameCache[name] = object.getGUID()
+            return object
+        end
+    end
+    error('_getByName: missing "' .. name .. '"')
+end
+
+function getRelicFragmentType(object)
+    return string.match(object.getName(), '^(%a+) Relic Fragment %(%d%)$')
+end
+
+function relocateRelicFragments(object)
+    local fragmentType = getRelicFragmentType(object)
+    if fragmentType then
+        local fragBag = _getByName(fragmentType .. ' Relic Fragments Bag', 'Bag')
+
+        if not fragBag then
+            return false
+        end
+
+        self.takeObject({
+            guid = object.getGUID(),
+            callback_function = function (obj)
+                fragBag.putObject(obj)
+            end
+        })
+
+        return true
+    end
+
+    return false
+end
+
 function onObjectEnterContainer(bag, enterObject)
     if bag == self then
-        printToAll('PURGING ' .. enterObject.getName(), 'Yellow')
+        if not relocateRelicFragments(enterObject) then --Try to handle known objects
+
+            --Otherwise the object is staying, so announce it
+            printToAll('PURGING ' .. enterObject.getName(), 'Yellow')
+        end
     end
 end
 
 function onObjectLeaveContainer(bag, leaveObject)
-    if bag == self then
+    if bag == self and not getRelicFragmentType(leaveObject) then
         printToAll("unPURGING " .. leaveObject.getName(), 'Yellow')
     end
 end


### PR DESCRIPTION
If someone puts a Relic Fragment into the Purge bag, this will move it into the correct "Relic Fragment Purge Bag", and suppress announcements for it