### PR TITLE
Check for Winnu Agent in the build area

### DIFF
--- a/Objects/TI4_BuildArea.ttslua
+++ b/Objects/TI4_BuildArea.ttslua
@@ -63,6 +63,11 @@ local OBJECT_EFFECTS = {
         requireFaceUp = true,
         warmachine = true,
     },
+
+    -- Leaders
+    ['Berekar Berekon'] = {
+        berekar = true,
+    },
 }
 
 local FACTION_EFFECTS = {
@@ -563,6 +568,7 @@ function getProduceConsumeItems()
         warmachine = false,
         aiDevelopmentAlgorithm = false,
         amalgamation = false,
+        berekar = false,
     }
 
     local unitsInBuildingArea = _getUnitsInsideBuildArea()
@@ -616,6 +622,7 @@ function getProduceConsumeItems()
             result.hegemonic = result.hegemonic or objectEffects.hegemonic
             result.warmachine = result.warmachine or objectEffects.warmachine
             result.aiDevelopmentAlgorithm = result.aiDevelopmentAlgorithm or objectEffects.aiDevelopmentAlgorithm
+            result.berekar = result.berekar or objectEffects.berekar
         end
     end
 
@@ -706,6 +713,10 @@ function getProduceConsumeResourcesAndCost(produceConsumeItems)
 
     if produceConsumeItems.aiDevelopmentAlgorithm then
         result.cost = math.max(result.cost - produceConsumeItems.aiDevelopmentAlgorithm, 0)
+    end
+
+    if produceConsumeItems.berekar then
+        result.cost = math.max(result.cost - 2, 0)
     end
 
     -- If Hegemonic Trade Policy (swap resouce/influence values), replace
@@ -1087,6 +1098,7 @@ function announce(items, resourcesAndCost)
         ' and total cost ' .. resourcesAndCost.cost,
         items.sarween and '-ST' or '',
         items.warmachine and '-WM' or '',
+        items.berekar and ' (BB)' or '',
         ',',
         ' consuming ' .. resourcesAndCost.resources,
         ' resources',


### PR DESCRIPTION
Detect Berekar Berekon when he's dropped into the build area.

When present, the  "Build cost:" is reduced by 2. The play button will report that the build cost was affected by Berekar with the note `(BB)`.

Quick note: Berekar affects cost similarly to War Machine and Sarween Tools. BUT, he has to be purposefully dragged into the build area; he does not affect every build. That is why I chose to modify the cost directly, rather than append a note to it (eg. "-ST").

![berekar-buildarea](https://user-images.githubusercontent.com/2775535/103060718-26d74900-4577-11eb-9a17-ca2751f63894.png)