### PR TITLE
Build area: Prevent dragging without player position

### DIFF
--- a/Objects/TI4_BuildArea.ttslua
+++ b/Objects/TI4_BuildArea.ttslua
@@ -405,7 +405,13 @@ function onInputValueChanged(player, value, id)
 end
 
 function onBeginDrag(player, option, id)
-    local pp = self.positionToLocal(player.getPointerPosition())
+    local gpp = player.getPointerPosition()
+    if not gpp then
+        _data.dragOffset = nil
+        return
+    end
+
+    local pp = self.positionToLocal(gpp)
     _data.dragOffset = {
         x = _data.width - pp.x,
         z = _data.height - pp.z
@@ -413,7 +419,12 @@ function onBeginDrag(player, option, id)
 end
 
 function onEndDrag(player, option, id)
-    local pp = self.positionToLocal(player.getPointerPosition())
+    local gpp = player.getPointerPosition()
+    if not gpp or not _data.dragOffset then
+        return
+    end
+
+    local pp = self.positionToLocal(gpp)
     _data.width = pp.x + _data.dragOffset.x
     _data.height = pp.z + _data.dragOffset.z
     _data.width = math.max(_data.width, _config.minWidth)
@@ -422,7 +433,12 @@ function onEndDrag(player, option, id)
 end
 
 function onDrag(player, option, id)
-    local pp = self.positionToLocal(player.getPointerPosition())
+    local gpp = player.getPointerPosition()
+    if not gpp or not _data.dragOffset then
+        return
+    end
+
+    local pp = self.positionToLocal(gpp)
     _data.width = pp.x + _data.dragOffset.x
     _data.height = pp.z + _data.dragOffset.z
     _data.width = math.max(_data.width, _config.minWidth)


### PR DESCRIPTION
Check that the player has a pointer position before allowing them to drag the build area bounding box around.

This isn't ideal. The corner will still be moved around by the position-less player. But it won't do anything at least, and won't spam errors.

This prevents errors from players that are spectating, or simply unseated.