### PR TITLE
make updateTechUI identify PoK tech through techHelper. Fixed a bug with the updateColorSelector.

### DIFF
--- a/Objects/StrategyCardAutomator.ttslua
+++ b/Objects/StrategyCardAutomator.ttslua
@@ -968,27 +968,26 @@ function _addTechnologyPrimarySecondary(layout)
 
 	if not _setupHelper.getPoK() then
 		-- remove pok tech from ui
-
+		local _techSourceSet = _technologyHelper.getTechSourceSet()
 		local techlist = {["greenTechs"] = true, ["yellowTechs"] = true, ["redTechs"] = true, ["blueTechs"] = true}
-		local horizontalKeep = {}
 		for _,o in pairs(layout[technologyIndex]["children"]) do
 			local counter = 1
 			if o["tag"] == "HorizontalLayout" and techlist[o["attributes"]["id"]] then
-				for iv,v in ipairs(o["children"]) do
-					if not (iv == 2) and not (iv == 4) then
-						horizontalKeep[counter] = v
+				local horizontalKeep = {}
+				for ibutton,button in ipairs(o["children"]) do
+					local techName = button['attributes']['onClick']
+					source = _techSourceSet(string.sub(techName, 10, -2))
+					if (not source) or (not source == "PoK") then
+						horizontalKeep[counter] = button
 						counter = counter + 1
 					end
 				end
 				o["children"] = _deepcopy(horizontalKeep)
 			end
 		end
-
 	end
 
 	table.insert(layout[technologyIndex]["children"], #layout - 1, _customLayout["technology_secondary"])
-	-- we no longer add the "Technology Primary" button, as it has no function.
-
 
 	return layout
 end

--- a/Objects/StrategyCardAutomator.ttslua
+++ b/Objects/StrategyCardAutomator.ttslua
@@ -969,7 +969,6 @@ function _addTechnologyPrimarySecondary(layout)
 	if not _setupHelper.getPoK() then
 		-- remove pok tech from ui
 		local _techSourceSet = _technologyHelper.getTechSourceSet()
-		log(_techSourceSet)
 		local techlist = {["greenTechs"] = true, ["yellowTechs"] = true, ["redTechs"] = true, ["blueTechs"] = true}
 		for _,o in pairs(layout[technologyIndex]["children"]) do
 			local counter = 1
@@ -978,9 +977,7 @@ function _addTechnologyPrimarySecondary(layout)
 				for ibutton,button in ipairs(o["children"]) do
 					local techName = button['attributes']['onClick']
 					source = _techSourceSet[string.sub(techName, 10, -2)]
-					log(source)
 					if not (source == "PoK") then
-						log('keeping '..source)
 						horizontalKeep[counter] = button
 						counter = counter + 1
 					end
@@ -1153,10 +1150,8 @@ function _updateColorSelector(layout, element, colorTable)
 	local newColorSelector = {}
 	local tempSelector = _deepcopy(_customLayout["colorSelector"])
 
-	-- colorTable = {"Red", "Greed", "Blue", "Indigo", "Violet", "Pink", "Orange"}
 	-- do 3 items per row, except for 4 players. There build 2x2
 	local maxButtonsPerRow = 2
-	log(colorTable)
 	if #colorTable == 4 then
 		maxButtonsPerRow = 1
 	end
@@ -1169,12 +1164,7 @@ function _updateColorSelector(layout, element, colorTable)
 		tempSelector["children"][colCounter] = _deepcopy(mybutton, {})
 		colCounter = colCounter + 1
 		--if in last row or row full
-		log(icolor)
-		log(icolor%3)
-		log(maxButtonsPerRow)
-		log(#colorTable)
 		if (icolor == #colorTable) or ((icolor-1)%3 == maxButtonsPerRow) then
-			log("nextRow")
 			table.insert(newColorSelector, #newColorSelector+1, _deepcopy(tempSelector))
 			colCounter = 1
 			tempSelector =  _deepcopy(_customLayout["colorSelector"])

--- a/Objects/StrategyCardAutomator.ttslua
+++ b/Objects/StrategyCardAutomator.ttslua
@@ -969,6 +969,7 @@ function _addTechnologyPrimarySecondary(layout)
 	if not _setupHelper.getPoK() then
 		-- remove pok tech from ui
 		local _techSourceSet = _technologyHelper.getTechSourceSet()
+		log(_techSourceSet)
 		local techlist = {["greenTechs"] = true, ["yellowTechs"] = true, ["redTechs"] = true, ["blueTechs"] = true}
 		for _,o in pairs(layout[technologyIndex]["children"]) do
 			local counter = 1
@@ -976,8 +977,10 @@ function _addTechnologyPrimarySecondary(layout)
 				local horizontalKeep = {}
 				for ibutton,button in ipairs(o["children"]) do
 					local techName = button['attributes']['onClick']
-					source = _techSourceSet(string.sub(techName, 10, -2))
-					if (not source) or (not source == "PoK") then
+					source = _techSourceSet[string.sub(techName, 10, -2)]
+					log(source)
+					if not (source == "PoK") then
+						log('keeping '..source)
 						horizontalKeep[counter] = button
 						counter = counter + 1
 					end
@@ -1147,16 +1150,15 @@ function _updateColorSelector(layout, element, colorTable)
 		return yourbutton
 	end
 
-	--make new color list
-	--colorTable = { "White", "Blue", "Purple", "Green" }
-
 	local newColorSelector = {}
 	local tempSelector = _deepcopy(_customLayout["colorSelector"])
 
+	-- colorTable = {"Red", "Greed", "Blue", "Indigo", "Violet", "Pink", "Orange"}
 	-- do 3 items per row, except for 4 players. There build 2x2
-	local maxButtonsPerRow = 3
+	local maxButtonsPerRow = 2
+	log(colorTable)
 	if #colorTable == 4 then
-		maxButtonsPerRow = 2
+		maxButtonsPerRow = 1
 	end
 
 	local colCounter = 1
@@ -1167,10 +1169,15 @@ function _updateColorSelector(layout, element, colorTable)
 		tempSelector["children"][colCounter] = _deepcopy(mybutton, {})
 		colCounter = colCounter + 1
 		--if in last row or row full
-		if (icolor == #colorTable) or (icolor%3 == maxButtonsPerRow) then
+		log(icolor)
+		log(icolor%3)
+		log(maxButtonsPerRow)
+		log(#colorTable)
+		if (icolor == #colorTable) or ((icolor-1)%3 == maxButtonsPerRow) then
+			log("nextRow")
 			table.insert(newColorSelector, #newColorSelector+1, _deepcopy(tempSelector))
 			colCounter = 1
-			tempSelector =  _customLayout["colorSelector"]
+			tempSelector =  _deepcopy(_customLayout["colorSelector"])
 		end
 	end
 

--- a/Objects/TI4_Helpers/TI4_TechnologyHelper.ttslua
+++ b/Objects/TI4_Helpers/TI4_TechnologyHelper.ttslua
@@ -193,6 +193,19 @@ function getTechNameSet()
 	return _techNameSet
 end
 
+local _techSourceSet = false
+
+function getTechSourceSet()
+	-- Returns list of sources for all technologies.
+	-- Names ending in " Ω" are not in list.
+	if not _techSourceSet then
+		_techSourceSet = {}
+		for k,v in pairs(_technologies) do
+			_techSourceSet[k] = getTechSource(k) or "Base"
+		end
+	end
+	return _techSourceSet
+end
 ------------------------------------------------------------------------------
 
 function _getPosParamsFromTechBoard(techBoard)


### PR DESCRIPTION
Found and fixed a bug in the way, the color buttons in TradeUI and PoliticsPopup (select speaker UI) were presented.
Made the removal of the PoK tech buttons in the TechnologyUI position independant and rely on the technologyHelper instead.
Added getSourceSet to minimize number of cross-object calls during updateUI call.