### PR TITLE
reseachTech now calls chainCallback() before it errors out, to not break techQueue

### DIFF
--- a/Objects/StrategyCardAutomator.ttslua
+++ b/Objects/StrategyCardAutomator.ttslua
@@ -911,521 +911,521 @@ function updateUiOnClick(player, option, alt)
 	if missingFactionColors then
 		local colors = table.concat(missingFactionColors, ', ')
 		broadcastToAll('Warning: no faction for ' .. colors .. '. Please repeat button click afterward to enable their faction technologies', 'Red')
-		end
-
-		local layout = UI.getXmlTable()
-
-		-- adds a tech primary and secondary to automatically consume the stategy token
-		-- removes PoK Buttons from tech UI if not playing with PoK
-		layout = _addTechnologyPrimarySecondary(layout)
-
-		-- adds the faction tech popup menu
-		layout = _addAutomationTechPopup(layout, factionColors)
-
-		-- adds on "Assign Speaker" button to Politics menu which opens the politics Popup
-		layout = _addAutomationPoliticsPopup(layout)
-
-		-- not implemented
-		-- layout = _addAutomationSecondaryPopup(layout, colorTable)
-
-		-- add a choice between scoring mecatol rex and drawing a secret
-		layout = _addImperialPrimary(layout)
-
-		-- adjusts the colors Table for the assign speaker politicsPopup
-		layout = _updateColorSelector(layout, "politicsPopup", colorTable)
-
-		-- adjusts the colors Table for the trade strategycard
-		layout = _updateColorSelector(layout, "trade", colorTable)
-
-		UI.setXmlTable(layout)
-		broadcastToAll("Updated strategy card menus for automator", "Yellow")
 	end
 
-	function _addTechnologyPrimarySecondary(layout)
-		-- adds a "Technology Primary" and "Technology Secondary" button to the tech menu.
-		-- The "Technology Primary" only announces "player uses Technology Primary" but does nothing
-		-- The "Technology Secondary" consumes a strategy token if necessary
-		-- If PoK not selected, remove PoK tech buttons from UI
+	local layout = UI.getXmlTable()
 
-		local technologyIndex = nil
+	-- adds a tech primary and secondary to automatically consume the stategy token
+	-- removes PoK Buttons from tech UI if not playing with PoK
+	layout = _addTechnologyPrimarySecondary(layout)
 
-		for majorIndex,menu in ipairs(layout) do
-			if menu["attributes"]["id"] == "technology" then
-				technologyIndex = majorIndex
-			end
+	-- adds the faction tech popup menu
+	layout = _addAutomationTechPopup(layout, factionColors)
+
+	-- adds on "Assign Speaker" button to Politics menu which opens the politics Popup
+	layout = _addAutomationPoliticsPopup(layout)
+
+	-- not implemented
+	-- layout = _addAutomationSecondaryPopup(layout, colorTable)
+
+	-- add a choice between scoring mecatol rex and drawing a secret
+	layout = _addImperialPrimary(layout)
+
+	-- adjusts the colors Table for the assign speaker politicsPopup
+	layout = _updateColorSelector(layout, "politicsPopup", colorTable)
+
+	-- adjusts the colors Table for the trade strategycard
+	layout = _updateColorSelector(layout, "trade", colorTable)
+
+	UI.setXmlTable(layout)
+	broadcastToAll("Updated strategy card menus for automator", "Yellow")
+end
+
+function _addTechnologyPrimarySecondary(layout)
+	-- adds a "Technology Primary" and "Technology Secondary" button to the tech menu.
+	-- The "Technology Primary" only announces "player uses Technology Primary" but does nothing
+	-- The "Technology Secondary" consumes a strategy token if necessary
+	-- If PoK not selected, remove PoK tech buttons from UI
+
+	local technologyIndex = nil
+
+	for majorIndex,menu in ipairs(layout) do
+		if menu["attributes"]["id"] == "technology" then
+			technologyIndex = majorIndex
 		end
+	end
 
-		if not technologyIndex then
-			error("Add technology primary secondary: No technology item found in ui", 'Red')
-			return layout
-		end
-
-		for _,o in pairs(layout[technologyIndex]["children"]) do
-			if o["attributes"]["id"] == "technology_secondary" then
-				return layout
-			end
-		end
-
-		if not _setupHelper.getPoK() then
-			-- remove pok tech from ui
-			local _techSourceSet = _technologyHelper.getTechSourceSet()
-			local techlist = {["greenTechs"] = true, ["yellowTechs"] = true, ["redTechs"] = true, ["blueTechs"] = true}
-			for _,o in pairs(layout[technologyIndex]["children"]) do
-				local counter = 1
-				if o["tag"] == "HorizontalLayout" and techlist[o["attributes"]["id"]] then
-					local horizontalKeep = {}
-					for ibutton,button in ipairs(o["children"]) do
-						local techName = button['attributes']['onClick']
-						source = _techSourceSet[string.sub(techName, 10, -2)]
-						if not (source == "PoK") then
-							horizontalKeep[counter] = button
-							counter = counter + 1
-						end
-					end
-					o["children"] = _deepcopy(horizontalKeep)
-				end
-			end
-		end
-
-		table.insert(layout[technologyIndex]["children"], #layout - 1, _customLayout["technology_secondary"])
-
+	if not technologyIndex then
+		error("Add technology primary secondary: No technology item found in ui", 'Red')
 		return layout
 	end
 
+	for _,o in pairs(layout[technologyIndex]["children"]) do
+		if o["attributes"]["id"] == "technology_secondary" then
+			return layout
+		end
+	end
 
-	function _addAutomationTechPopup(layout, colorTable)
-		-- finds the faction technology from faction.factionTech and adds a popup that opens on click of "Faction Tech" button.
-		-- the popup has the id color.."technologyPopup", so that each faction has its own factiontech popup
-		assert(type(colorTable) == "table")
-
-		local function _buildPopupTable(color)
-			local factionPopup = {}
-			factionPopup = _deepcopy(_customLayout["technologyPopupTable"])
-			factionPopup["attributes"].id = string.gsub(factionPopup["attributes"].id, "COLORPLACEHOLDER", color)
-
-			local faction = _factionHelper.fromColor(color)
-			if not faction then
-				broadcastToAll("_addAutomationTechPopup: no faction found for " .. color, "Red")
-				return factionPopup
-			end
-
-			if not faction.factionTech then
-				broadcastToAll("_addAutomationTechPopup: no factionTechnology found for " .. color, "Red")
-				return factionPopup
-			end
-
-			for _,factionTech in ipairs(faction.factionTech) do
-				local techPopupButton = _deepcopy(_customLayout["technologyPopupButton"])
-				for key,attr in pairs(techPopupButton["attributes"]) do
-					techPopupButton["attributes"][key] = string.gsub(attr, "TECHPLACEHOLDER", factionTech)
+	if not _setupHelper.getPoK() then
+		-- remove pok tech from ui
+		local _techSourceSet = _technologyHelper.getTechSourceSet()
+		local techlist = {["greenTechs"] = true, ["yellowTechs"] = true, ["redTechs"] = true, ["blueTechs"] = true}
+		for _,o in pairs(layout[technologyIndex]["children"]) do
+			local counter = 1
+			if o["tag"] == "HorizontalLayout" and techlist[o["attributes"]["id"]] then
+				local horizontalKeep = {}
+				for ibutton,button in ipairs(o["children"]) do
+					local techName = button['attributes']['onClick']
+					source = _techSourceSet[string.sub(techName, 10, -2)]
+					if not (source == "PoK") then
+						horizontalKeep[counter] = button
+						counter = counter + 1
+					end
 				end
-				table.insert(factionPopup["children"],2,techPopupButton)
+				o["children"] = _deepcopy(horizontalKeep)
 			end
+		end
+	end
 
+	table.insert(layout[technologyIndex]["children"], #layout - 1, _customLayout["technology_secondary"])
+
+	return layout
+end
+
+
+function _addAutomationTechPopup(layout, colorTable)
+	-- finds the faction technology from faction.factionTech and adds a popup that opens on click of "Faction Tech" button.
+	-- the popup has the id color.."technologyPopup", so that each faction has its own factiontech popup
+	assert(type(colorTable) == "table")
+
+	local function _buildPopupTable(color)
+		local factionPopup = {}
+		factionPopup = _deepcopy(_customLayout["technologyPopupTable"])
+		factionPopup["attributes"].id = string.gsub(factionPopup["attributes"].id, "COLORPLACEHOLDER", color)
+
+		local faction = _factionHelper.fromColor(color)
+		if not faction then
+			broadcastToAll("_addAutomationTechPopup: no faction found for " .. color, "Red")
 			return factionPopup
 		end
 
-		local inserted = false
-		for _,color in ipairs(colorTable) do
-			for index,menu in ipairs(layout) do
-				if menu["attributes"]["id"] == (color.."technologyPopup") then
-					inserted = true
-					-- updates existing COLORtechnologyPopup table in case of changed faction? Just to be sure...
-					table.remove(layout, index)
-					table.insert(layout, index, _buildPopupTable(color))
-					break
-				end
-			end
-			if not inserted then
-				table.insert(layout, _buildPopupTable(color))
-			end
+		if not faction.factionTech then
+			broadcastToAll("_addAutomationTechPopup: no factionTechnology found for " .. color, "Red")
+			return factionPopup
 		end
 
-		return layout
+		for _,factionTech in ipairs(faction.factionTech) do
+			local techPopupButton = _deepcopy(_customLayout["technologyPopupButton"])
+			for key,attr in pairs(techPopupButton["attributes"]) do
+				techPopupButton["attributes"][key] = string.gsub(attr, "TECHPLACEHOLDER", factionTech)
+			end
+			table.insert(factionPopup["children"],2,techPopupButton)
+		end
+
+		return factionPopup
 	end
 
-
-	-- adds a "Assign Speaker" Button. This opens the politicsPopup.
-	function _addAutomationPoliticsPopup(layout)
-		local politicsIndex = nil
-
-		for majorIndex,menu in ipairs(layout) do
-			if menu["attributes"]["id"] == "politicsPopup" then
-				return layout
-			end
-			if menu["attributes"]["id"] == "politics" then
-				politicsIndex = majorIndex
-			end
-		end
-
-		if not politicsIndex then
-			error("Add politics popup: No politics item found in ui", 'Red')
-			return layout
-		end
-
-		-- add the Assign Speaker Button which opens the Popup
-		table.insert(layout[politicsIndex]["children"], 2, _customLayout["assignSpeakerButton"])
-		-- add the Popup itself
-		table.insert(layout, #layout+1, _customLayout["politicsPopupTable"])
-
-		return layout
-	end
-
-
-	function _addAutomationSecondaryPopup(layout, factionTable)
-		-- UI.createButton not available for global UI. It would have been nice to use alt click,
-		-- to select alternative to using strategy token if available.
-		-- now consumeStrategyToken just exits if alternative is available to the player and tells the player what her alternative is.
-		log("_addAutomationSecondaryPopup not implemented yet")
-		assert(type(factionTable) == "table")
-		return layout
-	end
-
-	function _addImperialPrimary(layout)
-		-- adds the option to either score a point for mecatol rex (does nothing) or draw a secret
-		local imperialIndex
-		for majorIndex,menu in ipairs(layout) do
-			if menu["attributes"]["id"] == "imperial" then
-				imperialIndex = majorIndex
-				break
-			end
-		end
-
-		if not imperialIndex then
-			error("Add imperial primary : No imperial item found in ui", 'Red')
-			return layout
-		end
-
-		local insertIndex = nil
-		local keepTable = {}
-		for minorIndex,menu in ipairs(layout[imperialIndex]["children"]) do
-			if not (menu["attributes"]["id"] == "imperial_primary") then
-				table.insert(keepTable, menu)
-			else
-				insertIndex = minorIndex
-			end
-		end
-
-		if not insertIndex then
-			error("Add imperial primary: imperial_primary not found. No Substitution possible")
-		end
-
-		table.insert(keepTable, insertIndex, _customLayout["imperial"])
-		layout[imperialIndex]["children"] = keepTable
-		return layout
-	end
-
-	function _updateColorSelector(layout, element, colorTable)
-		assert(type(element) == "string")
-		local keepTable = {}
-		local elementIndex = 0
-
-		-- find the table to modify and copy all retained elements to keepTable.
-		-- keepTable replaces the old table by selectively not selecting colorSelector elements
+	local inserted = false
+	for _,color in ipairs(colorTable) do
 		for index,menu in ipairs(layout) do
-			if menu["attributes"]["id"] == element then
-				elementIndex = index
-				for minorIndex,child in ipairs(layout[elementIndex]["children"]) do
-					-- keep these entries
-					if not (child["attributes"]["id"] == "colorSelector") then
-						table.insert(keepTable, #keepTable+1, child)
-					end
-				end
+			if menu["attributes"]["id"] == (color.."technologyPopup") then
+				inserted = true
+				-- updates existing COLORtechnologyPopup table in case of changed faction? Just to be sure...
+				table.remove(layout, index)
+				table.insert(layout, index, _buildPopupTable(color))
 				break
 			end
 		end
-
-		local function _getColorButton(element, color)
-			local yourbutton = _deepcopy(_customLayout["colorButton"])
-			attributes = _deepcopy(_customLayout[element.."Attributes"])
-			for key,value in pairs(attributes) do
-				yourbutton["attributes"][key] = value
-			end
-			for key,value in pairs(yourbutton["attributes"]) do
-				yourbutton["attributes"][key] = string.gsub(value, "COLORPLACEHOLDER", color)
-			end
-			return yourbutton
+		if not inserted then
+			table.insert(layout, _buildPopupTable(color))
 		end
+	end
 
-		local newColorSelector = {}
-		local tempSelector = _deepcopy(_customLayout["colorSelector"])
+	return layout
+end
 
-		-- do 3 items per row, except for 4 players. There build 2x2
-		local maxButtonsPerRow = 2
-		if #colorTable == 4 then
-			maxButtonsPerRow = 1
+
+-- adds a "Assign Speaker" Button. This opens the politicsPopup.
+function _addAutomationPoliticsPopup(layout)
+	local politicsIndex = nil
+
+	for majorIndex,menu in ipairs(layout) do
+		if menu["attributes"]["id"] == "politicsPopup" then
+			return layout
 		end
-
-		local colCounter = 1
-
-		for icolor,color in ipairs(colorTable) do
-			local mybutton = _getColorButton(element, color)
-
-			tempSelector["children"][colCounter] = _deepcopy(mybutton, {})
-			colCounter = colCounter + 1
-			--if in last row or row full
-			if (icolor == #colorTable) or ((icolor-1)%3 == maxButtonsPerRow) then
-				table.insert(newColorSelector, #newColorSelector+1, _deepcopy(tempSelector))
-				colCounter = 1
-				tempSelector =  _deepcopy(_customLayout["colorSelector"])
-			end
+		if menu["attributes"]["id"] == "politics" then
+			politicsIndex = majorIndex
 		end
+	end
 
-		-- position 3 is hardcoded!!! if this were to change somehow we have a problem!
-		for _,newColumn in pairs(newColorSelector) do
-			table.insert(keepTable, 3, newColumn)
-		end
-		layout[elementIndex]["children"] = keepTable
-
+	if not politicsIndex then
+		error("Add politics popup: No politics item found in ui", 'Red')
 		return layout
 	end
 
+	-- add the Assign Speaker Button which opens the Popup
+	table.insert(layout[politicsIndex]["children"], 2, _customLayout["assignSpeakerButton"])
+	-- add the Popup itself
+	table.insert(layout, #layout+1, _customLayout["politicsPopupTable"])
 
-	----------------------------- Leadership ---------------------------------------
+	return layout
+end
 
-	function _dealLeadershipCommandTokens(color, count, dpos)
-		-- count is the number of command tokens to allocate,
-		-- dz is a global offset, so that primary and secondary command tokens are not stacked (for the primary player)
-		assert(type(dpos)=="table")
 
-		local faction = _factionHelper.fromColor(color)
-		if not faction then
-			broadcastToAll('Allocate command tokens: no faction for ' .. color, 'Red')
-			return
+function _addAutomationSecondaryPopup(layout, factionTable)
+	-- UI.createButton not available for global UI. It would have been nice to use alt click,
+	-- to select alternative to using strategy token if available.
+	-- now consumeStrategyToken just exits if alternative is available to the player and tells the player what her alternative is.
+	log("_addAutomationSecondaryPopup not implemented yet")
+	assert(type(factionTable) == "table")
+	return layout
+end
+
+function _addImperialPrimary(layout)
+	-- adds the option to either score a point for mecatol rex (does nothing) or draw a secret
+	local imperialIndex
+	for majorIndex,menu in ipairs(layout) do
+		if menu["attributes"]["id"] == "imperial" then
+			imperialIndex = majorIndex
+			break
 		end
+	end
 
-		local commandTokensBag = _getByName(faction.tokenName.." Command Tokens Bag", "Bag")
+	if not imperialIndex then
+		error("Add imperial primary : No imperial item found in ui", 'Red')
+		return layout
+	end
 
-		if not commandTokensBag then
-			broadcastToAll('Allocate command tokens: missing ' .. faction.tokenName .. ' Command Tokens Bag', 'Red')
-			return
+	local insertIndex = nil
+	local keepTable = {}
+	for minorIndex,menu in ipairs(layout[imperialIndex]["children"]) do
+		if not (menu["attributes"]["id"] == "imperial_primary") then
+			table.insert(keepTable, menu)
+		else
+			insertIndex = minorIndex
 		end
+	end
 
-		local commandSheet = getObjectFromGUID(faction.commandSheetGuid)
-		if not commandSheet then
-			broadcastToAll('Allocate command tokens: missing ' .. color .. ' Command Sheet', 'Red')
-			return
-		end
+	if not insertIndex then
+		error("Add imperial primary: imperial_primary not found. No Substitution possible")
+	end
 
-		local pos = { x = -0.1, y = 1, z = -5 }
-		local dx = -0.4
+	table.insert(keepTable, insertIndex, _customLayout["imperial"])
+	layout[imperialIndex]["children"] = keepTable
+	return layout
+end
 
-		-- Do the alloation.  Watch out for an empty bag!
-		local gained = 0
-		for i = 1, count do
-			if commandTokensBag.getQuantity() == 0 then
-				_safeBroadcastToColor('Leadership: ' .. color .. ' out of Command Tokens. Only able to gain ' .. i .. ' tokens. ', color, "Red")
-				break
+function _updateColorSelector(layout, element, colorTable)
+	assert(type(element) == "string")
+	local keepTable = {}
+	local elementIndex = 0
+
+	-- find the table to modify and copy all retained elements to keepTable.
+	-- keepTable replaces the old table by selectively not selecting colorSelector elements
+	for index,menu in ipairs(layout) do
+		if menu["attributes"]["id"] == element then
+			elementIndex = index
+			for minorIndex,child in ipairs(layout[elementIndex]["children"]) do
+				-- keep these entries
+				if not (child["attributes"]["id"] == "colorSelector") then
+					table.insert(keepTable, #keepTable+1, child)
+				end
 			end
-			local token = commandTokensBag.takeObject({
-				position = commandSheet.positionToWorld({
-					x = pos.x + (i * dx) + dpos.x,
-					y = pos.y + 1 + (i * 0.25) + dpos.y,
-					z = pos.z + dpos.z
-				})
+			break
+		end
+	end
+
+	local function _getColorButton(element, color)
+		local yourbutton = _deepcopy(_customLayout["colorButton"])
+		attributes = _deepcopy(_customLayout[element.."Attributes"])
+		for key,value in pairs(attributes) do
+			yourbutton["attributes"][key] = value
+		end
+		for key,value in pairs(yourbutton["attributes"]) do
+			yourbutton["attributes"][key] = string.gsub(value, "COLORPLACEHOLDER", color)
+		end
+		return yourbutton
+	end
+
+	local newColorSelector = {}
+	local tempSelector = _deepcopy(_customLayout["colorSelector"])
+
+	-- do 3 items per row, except for 4 players. There build 2x2
+	local maxButtonsPerRow = 2
+	if #colorTable == 4 then
+		maxButtonsPerRow = 1
+	end
+
+	local colCounter = 1
+
+	for icolor,color in ipairs(colorTable) do
+		local mybutton = _getColorButton(element, color)
+
+		tempSelector["children"][colCounter] = _deepcopy(mybutton, {})
+		colCounter = colCounter + 1
+		--if in last row or row full
+		if (icolor == #colorTable) or ((icolor-1)%3 == maxButtonsPerRow) then
+			table.insert(newColorSelector, #newColorSelector+1, _deepcopy(tempSelector))
+			colCounter = 1
+			tempSelector =  _deepcopy(_customLayout["colorSelector"])
+		end
+	end
+
+	-- position 3 is hardcoded!!! if this were to change somehow we have a problem!
+	for _,newColumn in pairs(newColorSelector) do
+		table.insert(keepTable, 3, newColumn)
+	end
+	layout[elementIndex]["children"] = keepTable
+
+	return layout
+end
+
+
+----------------------------- Leadership ---------------------------------------
+
+function _dealLeadershipCommandTokens(color, count, dpos)
+	-- count is the number of command tokens to allocate,
+	-- dz is a global offset, so that primary and secondary command tokens are not stacked (for the primary player)
+	assert(type(dpos)=="table")
+
+	local faction = _factionHelper.fromColor(color)
+	if not faction then
+		broadcastToAll('Allocate command tokens: no faction for ' .. color, 'Red')
+		return
+	end
+
+	local commandTokensBag = _getByName(faction.tokenName.." Command Tokens Bag", "Bag")
+
+	if not commandTokensBag then
+		broadcastToAll('Allocate command tokens: missing ' .. faction.tokenName .. ' Command Tokens Bag', 'Red')
+		return
+	end
+
+	local commandSheet = getObjectFromGUID(faction.commandSheetGuid)
+	if not commandSheet then
+		broadcastToAll('Allocate command tokens: missing ' .. color .. ' Command Sheet', 'Red')
+		return
+	end
+
+	local pos = { x = -0.1, y = 1, z = -5 }
+	local dx = -0.4
+
+	-- Do the alloation.  Watch out for an empty bag!
+	local gained = 0
+	for i = 1, count do
+		if commandTokensBag.getQuantity() == 0 then
+			_safeBroadcastToColor('Leadership: ' .. color .. ' out of Command Tokens. Only able to gain ' .. i .. ' tokens. ', color, "Red")
+			break
+		end
+		local token = commandTokensBag.takeObject({
+			position = commandSheet.positionToWorld({
+				x = pos.x + (i * dx) + dpos.x,
+				y = pos.y + 1 + (i * 0.25) + dpos.y,
+				z = pos.z + dpos.z
 			})
-			_strategyCardHelper._addUnallocatedCommandToken(token, color)
-			gained = gained + 1
-		end
-
-		_safeBroadcastToColor('Leadership: ' .. color .. ' gained ' .. gained .. ' Command Tokens.', color, color)
-	end
-
-	------------------------------ secondary ---------------------------------------
-
-	function _consumeStrategyToken(color, strategyCard)
-		assert(type(color) == 'string' and type(strategyCard) == 'string')
-
-		local faction = _factionHelper.fromColor(color)
-		if not faction then
-			broadcastToAll('Consume Strategy tokens: no faction for ' .. color, 'Red')
-			return
-		end
-
-		local SsruuActive = false
-		local JaeMirKanActive = false
-
-		-- find command token bag
-		-- also check if alternate command token payment method available.
-		-- if so, message the player and return true
-		local commandTokensBag
-
-		if not _setupHelper.getPoK() then
-			commandTokensBag = _getByName(faction.tokenName .. " Command Tokens Bag", "Bag")
-		else
-			for _, object in ipairs(getAllObjects()) do
-				local name = object.getName()
-				local guid = object.getGUID()
-				if object.tag == 'Bag' then
-					if name == faction.tokenName .. " Command Tokens Bag" then
-						commandTokensBag = object
-					end
-				end
-
-				if (name == "Jae Mir Kan") then
-					JaeMirKanActive = true
-					if (faction.name == "The Mahact Gene-Sorcerers") and (not object.is_face_down) then
-						_safeBroadcastToColor(strategyCard .. ": Jae Mir Kan is available to you. No Token has been used.", color,color)
-						return true
-					end
-				elseif (faction.name == "The Yssaril Tribes") and (name == "Ssruu") and (not object.is_face_down) then
-					SsruuActive = true
-				end
-
-				if (name == "Scepter of Emelpar") and (not object.is_face_down) then
-					local zoneColor = _zoneHelper.zoneFromPosition(object.getPosition())
-					if zoneColor == color then
-						_safeBroadcastToColor(strategyCard .. ": Scepter of Emelpar is available to you. No Token has been used.", color, color)
-						return true
-					end
-
-				end
-			end
-
-			if (SsruuActive and JaeMirKanActive) then
-				_safeBroadcastToColor(strategyCard .. ": Ssruu is available to you. No Token has been used.", color, color)
-				return true
-			end
-		end
-
-		if not commandTokensBag then
-			broadcastToAll('Consume Strategy tokens: missing ' .. faction.tokenName .. ' Command Tokens Bag', 'Red')
-			return
-		end
-
-		local commandSheet = getObjectFromGUID(faction.commandSheetGuid)
-		if not commandSheet then
-			broadcastToAll('Consume Strategy tokens: missing ' .. color .. ' Command Sheet', 'Red')
-			return
-		end
-
-		-- todo: change cast and use sheet.positionToLocal instead. check if z > 0 or < 0 or something.
-
-		local commandTokenName = faction.tokenName .. " Command Token"
-		for _,object in ipairs(getAllObjects()) do
-			local name = object.getName()
-			if name == commandTokenName then
-				local rot = object.getRotation()['z']
-				if rot < 90 or rot > 270 then
-					local pos = commandSheet.positionToLocal(object.getPosition())
-					if pos.x < 2 and pos.x > -4 and pos.z > -0.3 and pos.z < 3.5 then
-						commandTokensBag.putObject(object)
-						_safeBroadcastToColor(strategyCard .. ": removed one Command Token from " .. color .. "'s strategy pool.", color, color)
-						return true
-					end
-				end
-			end
-		end
-
-		_safeBroadcastToColor(strategyCard .. ": no command token in " .. color .. "'s strategy pool.", color, "Red")
-		return false
-	end
-
-	-------------------------------- Politics --------------------------------------
-
-	function _moveSpeakerToken(color)
-		local speakerToken = nil
-		speakerToken = _getByName("Speaker Token")
-		if not speakerToken then
-			broadcastToAll('Assign speaker token: missing Speaker Token', 'Red')
-			return
-		end
-
-		zone = _zoneHelper.zoneAttributes(color)
-		if not zone then
-			broadcastToAll('Assign speaker token: missing ' .. color .. ' player area', 'Red')
-			return
-		end
-
-		local loc = _getSpeakerLoc(zone)
-		local rot = zone.rotation
-
-		speakerToken.setPositionSmooth(loc, false, true)
-		speakerToken.setRotationSmooth(rot, false, true)
-
-		broadcastToAll(color .. " is the new speaker.", color)
-		return true
-	end
-
-	-- Get corner of zone closest to the system.
-	-- also tested for 7 and 8 players
-	function _getSpeakerLoc(zone)
-		local polygons = zone.polygon
-
-		-- get any z value closest to the system map.
-		local minz = math.abs(polygons[1][2])
-		local i_minz = 1
-		for k,poly in ipairs(polygons) do
-			if math.abs(poly[2]) < minz then
-				minz = math.abs(poly[2])
-				i_minz = k
-			end
-		end
-		local z = polygons[i_minz][2]
-
-
-		-- get the x value closest to the system map, with the matching z value.
-		local minx = math.abs(polygons[i_minz][1])
-		local i_minx = 1
-		for k,poly in ipairs(polygons) do
-			if (z == poly[2]) and (math.abs(poly[1]) <= minx) then
-				minx = math.abs(poly[1])
-				i_minx = k
-			end
-		end
-		local x = polygons[i_minx][1]
-
-		-- shift the token slightly into the zone.
-		if z > 0 then z = z + 3 else z = z - 3 end
-		if x > 0 then x = x + 4 else x = x - 4 end
-
-		return {x=x ,y=2, z=z}
-	end
-
-	-- option can be "self" or target "COLOR".
-	function _assignSpeaker(color, option)
-		local res
-		if option=="self" then
-			res = _moveSpeakerToken(color)
-		else
-			res = _moveSpeakerToken(option)
-		end
-		return res
-	end
-
-	function _dealPoliticsActionCards(color)
-		local counter = 2
-
-		local faction = _factionHelper.fromColor(color)
-		if not faction then
-			broadcastToAll('Deal Action Cards: no faction for ' .. color, 'Red')
-			return
-		end
-
-		local abilitiesSet = {}
-		for _, ability in ipairs(faction.abilities) do
-
-			abilitiesSet[ability] = true
-		end
-		if abilitiesSet['Scheming'] then
-			broadcastToAll("Scheming.", color)
-			counter = counter + 1
-		end
-
-		_deckHelper.deal({
-			deck = 'Actions',
-			count = counter,
-			color = color,
 		})
+		_strategyCardHelper._addUnallocatedCommandToken(token, color)
+		gained = gained + 1
 	end
 
+	_safeBroadcastToColor('Leadership: ' .. color .. ' gained ' .. gained .. ' Command Tokens.', color, color)
+end
 
-	function _dealPoliticsAgendas(color)
+------------------------------ secondary ---------------------------------------
+
+function _consumeStrategyToken(color, strategyCard)
+	assert(type(color) == 'string' and type(strategyCard) == 'string')
+
+	local faction = _factionHelper.fromColor(color)
+	if not faction then
+		broadcastToAll('Consume Strategy tokens: no faction for ' .. color, 'Red')
+		return
+	end
+
+	local SsruuActive = false
+	local JaeMirKanActive = false
+
+	-- find command token bag
+	-- also check if alternate command token payment method available.
+	-- if so, message the player and return true
+	local commandTokensBag
+
+	if not _setupHelper.getPoK() then
+		commandTokensBag = _getByName(faction.tokenName .. " Command Tokens Bag", "Bag")
+	else
+		for _, object in ipairs(getAllObjects()) do
+			local name = object.getName()
+			local guid = object.getGUID()
+			if object.tag == 'Bag' then
+				if name == faction.tokenName .. " Command Tokens Bag" then
+					commandTokensBag = object
+				end
+			end
+
+			if (name == "Jae Mir Kan") then
+				JaeMirKanActive = true
+				if (faction.name == "The Mahact Gene-Sorcerers") and (not object.is_face_down) then
+					_safeBroadcastToColor(strategyCard .. ": Jae Mir Kan is available to you. No Token has been used.", color,color)
+					return true
+				end
+			elseif (faction.name == "The Yssaril Tribes") and (name == "Ssruu") and (not object.is_face_down) then
+				SsruuActive = true
+			end
+
+			if (name == "Scepter of Emelpar") and (not object.is_face_down) then
+				local zoneColor = _zoneHelper.zoneFromPosition(object.getPosition())
+				if zoneColor == color then
+					_safeBroadcastToColor(strategyCard .. ": Scepter of Emelpar is available to you. No Token has been used.", color, color)
+					return true
+				end
+
+			end
+		end
+
+		if (SsruuActive and JaeMirKanActive) then
+			_safeBroadcastToColor(strategyCard .. ": Ssruu is available to you. No Token has been used.", color, color)
+			return true
+		end
+	end
+
+	if not commandTokensBag then
+		broadcastToAll('Consume Strategy tokens: missing ' .. faction.tokenName .. ' Command Tokens Bag', 'Red')
+		return
+	end
+
+	local commandSheet = getObjectFromGUID(faction.commandSheetGuid)
+	if not commandSheet then
+		broadcastToAll('Consume Strategy tokens: missing ' .. color .. ' Command Sheet', 'Red')
+		return
+	end
+
+	-- todo: change cast and use sheet.positionToLocal instead. check if z > 0 or < 0 or something.
+
+	local commandTokenName = faction.tokenName .. " Command Token"
+	for _,object in ipairs(getAllObjects()) do
+		local name = object.getName()
+		if name == commandTokenName then
+			local rot = object.getRotation()['z']
+			if rot < 90 or rot > 270 then
+				local pos = commandSheet.positionToLocal(object.getPosition())
+				if pos.x < 2 and pos.x > -4 and pos.z > -0.3 and pos.z < 3.5 then
+					commandTokensBag.putObject(object)
+					_safeBroadcastToColor(strategyCard .. ": removed one Command Token from " .. color .. "'s strategy pool.", color, color)
+					return true
+				end
+			end
+		end
+	end
+
+	_safeBroadcastToColor(strategyCard .. ": no command token in " .. color .. "'s strategy pool.", color, "Red")
+	return false
+end
+
+-------------------------------- Politics --------------------------------------
+
+function _moveSpeakerToken(color)
+	local speakerToken = nil
+	speakerToken = _getByName("Speaker Token")
+	if not speakerToken then
+		broadcastToAll('Assign speaker token: missing Speaker Token', 'Red')
+		return
+	end
+
+	zone = _zoneHelper.zoneAttributes(color)
+	if not zone then
+		broadcastToAll('Assign speaker token: missing ' .. color .. ' player area', 'Red')
+		return
+	end
+
+	local loc = _getSpeakerLoc(zone)
+	local rot = zone.rotation
+
+	speakerToken.setPositionSmooth(loc, false, true)
+	speakerToken.setRotationSmooth(rot, false, true)
+
+	broadcastToAll(color .. " is the new speaker.", color)
+	return true
+end
+
+-- Get corner of zone closest to the system.
+-- also tested for 7 and 8 players
+function _getSpeakerLoc(zone)
+	local polygons = zone.polygon
+
+	-- get any z value closest to the system map.
+	local minz = math.abs(polygons[1][2])
+	local i_minz = 1
+	for k,poly in ipairs(polygons) do
+		if math.abs(poly[2]) < minz then
+			minz = math.abs(poly[2])
+			i_minz = k
+		end
+	end
+	local z = polygons[i_minz][2]
+
+
+	-- get the x value closest to the system map, with the matching z value.
+	local minx = math.abs(polygons[i_minz][1])
+	local i_minx = 1
+	for k,poly in ipairs(polygons) do
+		if (z == poly[2]) and (math.abs(poly[1]) <= minx) then
+			minx = math.abs(poly[1])
+			i_minx = k
+		end
+	end
+	local x = polygons[i_minx][1]
+
+	-- shift the token slightly into the zone.
+	if z > 0 then z = z + 3 else z = z - 3 end
+	if x > 0 then x = x + 4 else x = x - 4 end
+
+	return {x=x ,y=2, z=z}
+end
+
+-- option can be "self" or target "COLOR".
+function _assignSpeaker(color, option)
+	local res
+	if option=="self" then
+		res = _moveSpeakerToken(color)
+	else
+		res = _moveSpeakerToken(option)
+	end
+	return res
+end
+
+function _dealPoliticsActionCards(color)
+	local counter = 2
+
+	local faction = _factionHelper.fromColor(color)
+	if not faction then
+		broadcastToAll('Deal Action Cards: no faction for ' .. color, 'Red')
+		return
+	end
+
+	local abilitiesSet = {}
+	for _, ability in ipairs(faction.abilities) do
+
+		abilitiesSet[ability] = true
+	end
+	if abilitiesSet['Scheming'] then
+		broadcastToAll("Scheming.", color)
+		counter = counter + 1
+	end
+
 	_deckHelper.deal({
-		deck = 'Agenda',
-		count = 2,
+		deck = 'Actions',
+		count = counter,
 		color = color,
 	})
+end
+
+
+function _dealPoliticsAgendas(color)
+_deckHelper.deal({
+	deck = 'Agenda',
+	count = 2,
+	color = color,
+})
 end
 
 -------------------------------- Construction ----------------------------------

--- a/Objects/StrategyCardAutomator.ttslua
+++ b/Objects/StrategyCardAutomator.ttslua
@@ -324,12 +324,12 @@ function onLoad()
 
 	for card, _ in pairs(_workQueue) do
 		_workQueue[card]['primaryColor'] = nil
-		_workQueue[card]['job'] = {}
 		_workQueue[card]['done'] = {}
+		_workQueue[card]['job'] = {}
 
 		for _,c in pairs(_colors) do
-			_workQueue[card]['job'][c] = false
 			_workQueue[card]['done'][c] = false
+			_workQueue[card]['job'][c] = false
 		end
 	end
 
@@ -517,30 +517,35 @@ function onStrategyCardButtonClicked(params)
 				-- primary passes "self" or COLOR as option
 				local success = _assignSpeaker(color, option)
 				if success then
-					_workQueue[card]["primaryColor"] = color
-					_workQueue[card]["done"][color] = true
-					_workQueue[card]["job"][color] = true
-					_dealWorkQueueCards(card, color)
+					_dealPoliticsActionCards(color)
 					-- wait to deal agendas, then they arrive grouped in the hand.
 					Wait.frames(function() _dealPoliticsAgendas(color) end,3)
 
+					_workQueue[card]["done"][color] = true
+					if _useWorkQueue then
+						_dealWorkQueueCards(card)
+					end
 					_closePopupUi(color, card.."Popup")
 				end
 			end
 		end
 		if (action == "secondary") and secondarySuccessful then
-			_workQueue[card]["done"][color] = true
-			_workQueue[card]["job"][color] = true
-			_dealWorkQueueCards(card, color)
+			if _useWorkQueue then
+				_workQueue[card]["done"][color] = true
+				_workQueue[card]["job"][color] = true
+				_dealWorkQueueCards(card)
+			else
+				_dealPoliticsActionCards(color)
+			end
 			_closeMenu(color, card)
 		end
 	end
 
-	-------------------------- Construction --------------------------------------
+	--------------------------  Trade ------------------------------------------
 
 	if card == "construction" then
 		local constructionSuccessful = false
-		
+
 		if action == "primary" then
 			if option == "a Space Dock and a PDS" then
 				constructionSuccessful = _allocateConstructionUnits(color, {"PDS", "Space Dock"})
@@ -552,12 +557,10 @@ function onStrategyCardButtonClicked(params)
 			constructionSuccessful = _allocateConstructionUnits(color, {"Command Token", string.sub(option, 3, -1)})
 		end
 		if constructionSuccessful then
-			
+
 			_closeMenu(color,card)
 		end
 	end
-
-	--------------------------  Trade ------------------------------------------
 
 	if card == "trade" then
 		if action == "primary" then
@@ -612,12 +615,17 @@ function onStrategyCardButtonClicked(params)
 				_dealImperialSecret(color)
 				_closeMenu(color, card)
 			end
-			_workQueue[card]['done']=true
-			_dealWorkQueueCards(card, color)
+			if _useWorkQueue then
+				_dealWorkQueueCards(card)
+			end
 		elseif (action == "secondary") and secondarySuccessful then
-			_workQueue[card]['job'][color] = true
-			_workQueue[card]['done'][color] = true
-			_dealWorkQueueCards(card, color)
+			if _useWorkQueue then
+				_workQueue[card]['job'][color] = true
+				_workQueue[card]['done'][color] = true
+				_dealWorkQueueCards(card)
+			else
+				_dealImperialSecret(color)
+			end
 			_closeMenu(color, card)
 		end
 	end
@@ -644,36 +652,47 @@ end
 
 --------------------------------------------------------------------------------
 
-local _workQueueFunctionMap = {
-	["politics"] = function(color) _dealPoliticsActionCards(color) end,
-	["imperial"] = function(color) _dealImperialSecret(color) end
-}
-
-function _dealWorkQueueCards(card, color)
-	if not _workQueueFunctionMap[card] then return end
-	
-	local colorTable _zoneHelper.zones()
-	
+function _dealWorkQueueCards(card)
+	-- currently disabled
 	if not _useWorkQueue then
-		_workQueue[card]['job'][color] = false
-		_workQueueFunctionMap[card](color)
 		return
 	end
 
-	local primaryColor = _workQueue[card]["primaryColor"]
-	if not primaryColor then return	end
+	if not _workQueue[card]["primaryColor"] then
+		return
+	end
+
+	--duplicate the colorTable
+	local doubleTable = {}
+	doubleTable = getSeatedPlayers()
+	for _,v in ipairs(getSeatedPlayers()) do
+		table.insert(doubleTable, v)
+	end
+
+	local function _doWork(card, color)
+		if card == "imperial" then
+			_dealImperialSecret(color)
+		end
+		if card == "politics" then
+			_dealPoliticsActionCards(color)
+		end
+		return
+	end
 
 	local started = false
-	local mappedIndex
-	for index = 1, 2*#colorTable do
-		c = colorTable[(index - 1) % #colorTable +1]
-		started = started or (c == primaryColor)
+	for index,color in ipairs(doubleTable) do
+
+		if color == _workQueue[card]['primaryColor'] then
+			started = true
+		end
 		if started then
-			if not _workQueue[card]['done'][c] then
+			if _workQueue[card]['done'][color] then
+				if _workQueue[card]['job'][color] then
+					_doWork(card, color)
+					_workQueue[card]['job'][color] = false
+				end
+			else
 				return
-			elseif _workQueue[card]['job'][c] then
-				_workQueue[card]['job'][c] = false
-				_workQueueFunctionMap[card](c)
 			end
 		end
 	end
@@ -681,17 +700,38 @@ end
 
 
 function _clearWorkQueue(card)
-	if not (_useWorkQueue and _workQueueFunctionMap[card]) then return	end
+	-- currently disabled
+	if not _useWorkQueue then
+		return
+	end
 
-	local colorTable = _zoneHelper.zones()
-	
+	local function _doWork(card, color)
+		if card == "imperial" then
+			_dealImperialSecret(color)
+		end
+		if card == "politics" then
+			_dealPoliticsActionCards(color)
+		end
+		return
+	end
+
+	for color,job in pairs(_workQueue[card]['job']) do
+		for _,c in ipairs(getSeatedPlayers()) do
+			if c == color then
+				if job then
+					_doWork(card, color)
+				end
+			end
+		end
+	end
+
 	_workQueue[card]['primaryColor'] = nil
-	for _,color in ipairs(colorTable) do
-		if _workQueue[card]['job'][color] then
-			_workQueue[card]['job'][c] = false
-			_workQueueFunctionMap[card](color)
+	local _colors = _setupHelper.getSetupColors()
+	for _,c in ipairs(_colors) do
+		if _workQueue[card]['job'][c] then
 		end
 		_workQueue[card]['done'][c] = false
+		_workQueue[card]['job'][c] = false
 	end
 end
 
@@ -840,7 +880,9 @@ function _closeMenu(color, card)
 		UI.setAttribute(card, "active", "false")
 		if not popup then
 			broadcastToAll("All players have responded", "Black")
-			_clearWorkQueue(card)
+			if _useWorkQueue then
+				_clearWorkQueue(card)
+			end
 		end
 	end
 	UI.setAttribute(card, "visibility", newVis)

--- a/Objects/StrategyCardAutomator.ttslua
+++ b/Objects/StrategyCardAutomator.ttslua
@@ -324,12 +324,12 @@ function onLoad()
 
 	for card, _ in pairs(_workQueue) do
 		_workQueue[card]['primaryColor'] = nil
-		_workQueue[card]['done'] = {}
 		_workQueue[card]['job'] = {}
+		_workQueue[card]['done'] = {}
 
 		for _,c in pairs(_colors) do
-			_workQueue[card]['done'][c] = false
 			_workQueue[card]['job'][c] = false
+			_workQueue[card]['done'][c] = false
 		end
 	end
 
@@ -517,35 +517,30 @@ function onStrategyCardButtonClicked(params)
 				-- primary passes "self" or COLOR as option
 				local success = _assignSpeaker(color, option)
 				if success then
-					_dealPoliticsActionCards(color)
+					_workQueue[card]["primaryColor"] = color
+					_workQueue[card]["done"][color] = true
+					_workQueue[card]["job"][color] = true
+					_dealWorkQueueCards(card, color)
 					-- wait to deal agendas, then they arrive grouped in the hand.
 					Wait.frames(function() _dealPoliticsAgendas(color) end,3)
 
-					_workQueue[card]["done"][color] = true
-					if _useWorkQueue then
-						_dealWorkQueueCards(card)
-					end
 					_closePopupUi(color, card.."Popup")
 				end
 			end
 		end
 		if (action == "secondary") and secondarySuccessful then
-			if _useWorkQueue then
-				_workQueue[card]["done"][color] = true
-				_workQueue[card]["job"][color] = true
-				_dealWorkQueueCards(card)
-			else
-				_dealPoliticsActionCards(color)
-			end
+			_workQueue[card]["done"][color] = true
+			_workQueue[card]["job"][color] = true
+			_dealWorkQueueCards(card, color)
 			_closeMenu(color, card)
 		end
 	end
 
-	--------------------------  Trade ------------------------------------------
+	-------------------------- Construction --------------------------------------
 
 	if card == "construction" then
 		local constructionSuccessful = false
-
+		
 		if action == "primary" then
 			if option == "a Space Dock and a PDS" then
 				constructionSuccessful = _allocateConstructionUnits(color, {"PDS", "Space Dock"})
@@ -557,10 +552,12 @@ function onStrategyCardButtonClicked(params)
 			constructionSuccessful = _allocateConstructionUnits(color, {"Command Token", string.sub(option, 3, -1)})
 		end
 		if constructionSuccessful then
-
+			
 			_closeMenu(color,card)
 		end
 	end
+
+	--------------------------  Trade ------------------------------------------
 
 	if card == "trade" then
 		if action == "primary" then
@@ -615,17 +612,12 @@ function onStrategyCardButtonClicked(params)
 				_dealImperialSecret(color)
 				_closeMenu(color, card)
 			end
-			if _useWorkQueue then
-				_dealWorkQueueCards(card)
-			end
+			_workQueue[card]['done']=true
+			_dealWorkQueueCards(card, color)
 		elseif (action == "secondary") and secondarySuccessful then
-			if _useWorkQueue then
-				_workQueue[card]['job'][color] = true
-				_workQueue[card]['done'][color] = true
-				_dealWorkQueueCards(card)
-			else
-				_dealImperialSecret(color)
-			end
+			_workQueue[card]['job'][color] = true
+			_workQueue[card]['done'][color] = true
+			_dealWorkQueueCards(card, color)
 			_closeMenu(color, card)
 		end
 	end
@@ -652,47 +644,36 @@ end
 
 --------------------------------------------------------------------------------
 
-function _dealWorkQueueCards(card)
-	-- currently disabled
+local _workQueueFunctionMap = {
+	["politics"] = function(color) _dealPoliticsActionCards(color) end,
+	["imperial"] = function(color) _dealImperialSecret(color) end
+}
+
+function _dealWorkQueueCards(card, color)
+	if not _workQueueFunctionMap[card] then return end
+	
+	local colorTable _zoneHelper.zones()
+	
 	if not _useWorkQueue then
+		_workQueue[card]['job'][color] = false
+		_workQueueFunctionMap[card](color)
 		return
 	end
 
-	if not _workQueue[card]["primaryColor"] then
-		return
-	end
-
-	--duplicate the colorTable
-	local doubleTable = {}
-	doubleTable = getSeatedPlayers()
-	for _,v in ipairs(getSeatedPlayers()) do
-		table.insert(doubleTable, v)
-	end
-
-	local function _doWork(card, color)
-		if card == "imperial" then
-			_dealImperialSecret(color)
-		end
-		if card == "politics" then
-			_dealPoliticsActionCards(color)
-		end
-		return
-	end
+	local primaryColor = _workQueue[card]["primaryColor"]
+	if not primaryColor then return	end
 
 	local started = false
-	for index,color in ipairs(doubleTable) do
-
-		if color == _workQueue[card]['primaryColor'] then
-			started = true
-		end
+	local mappedIndex
+	for index = 1, 2*#colorTable do
+		c = colorTable[(index - 1) % #colorTable +1]
+		started = started or (c == primaryColor)
 		if started then
-			if _workQueue[card]['done'][color] then
-				if _workQueue[card]['job'][color] then
-					_doWork(card, color)
-					_workQueue[card]['job'][color] = false
-				end
-			else
+			if not _workQueue[card]['done'][c] then
 				return
+			elseif _workQueue[card]['job'][c] then
+				_workQueue[card]['job'][c] = false
+				_workQueueFunctionMap[card](c)
 			end
 		end
 	end
@@ -700,38 +681,17 @@ end
 
 
 function _clearWorkQueue(card)
-	-- currently disabled
-	if not _useWorkQueue then
-		return
-	end
+	if not (_useWorkQueue and _workQueueFunctionMap[card]) then return	end
 
-	local function _doWork(card, color)
-		if card == "imperial" then
-			_dealImperialSecret(color)
-		end
-		if card == "politics" then
-			_dealPoliticsActionCards(color)
-		end
-		return
-	end
-
-	for color,job in pairs(_workQueue[card]['job']) do
-		for _,c in ipairs(getSeatedPlayers()) do
-			if c == color then
-				if job then
-					_doWork(card, color)
-				end
-			end
-		end
-	end
-
+	local colorTable = _zoneHelper.zones()
+	
 	_workQueue[card]['primaryColor'] = nil
-	local _colors = _setupHelper.getSetupColors()
-	for _,c in ipairs(_colors) do
-		if _workQueue[card]['job'][c] then
+	for _,color in ipairs(colorTable) do
+		if _workQueue[card]['job'][color] then
+			_workQueue[card]['job'][c] = false
+			_workQueueFunctionMap[card](color)
 		end
 		_workQueue[card]['done'][c] = false
-		_workQueue[card]['job'][c] = false
 	end
 end
 
@@ -880,9 +840,7 @@ function _closeMenu(color, card)
 		UI.setAttribute(card, "active", "false")
 		if not popup then
 			broadcastToAll("All players have responded", "Black")
-			if _useWorkQueue then
-				_clearWorkQueue(card)
-			end
+			_clearWorkQueue(card)
 		end
 	end
 	UI.setAttribute(card, "visibility", newVis)
@@ -908,6 +866,7 @@ function updateUiOnClick(player, option, alt)
 		end
 		table.insert(colorTable, color)
 	end
+
 	if missingFactionColors then
 		local colors = table.concat(missingFactionColors, ', ')
 		broadcastToAll('Warning: no faction for ' .. colors .. '. Please repeat button click afterward to enable their faction technologies', 'Red')
@@ -1628,11 +1587,13 @@ function researchTech(color, cardName, chainCallback)
 	local faction = _factionHelper.fromColor(color)
 	if not faction then
 		broadcastToAll('Research Technology: no faction selected for ' .. color, 'Red')
+		chainCallback()
 		return
 	end
 
 	-- "Faction Tech" handled by onStrategyCardButtonClicked.
 	if cardName == "Faction Tech" then
+		chainCallback()
 		return
 
 		-- gain command tokens only available to necro
@@ -1643,9 +1604,11 @@ function researchTech(color, cardName, chainCallback)
 		end
 		if abilitiesSet['Technological Singularity'] then
 			_dealLeadershipCommandTokens(color, 3, {x=0,y=0,z=0})
+			chainCallback()
 			return
 		else
 			_safeBroadcastToColor("Can only gain command tokens as Nekro", color, "Red")
+			chainCallback()
 			return
 		end
 	end
@@ -1658,12 +1621,14 @@ function researchTech(color, cardName, chainCallback)
 	local techType = _technologyHelper.getTechType(cardName)
 	if not techType then
 		log('_technologyHelper did not find "' .. cardName .. '"')
+		chainCallback()
 		return
 	end
 
 	local techNameSet = _technologyHelper.getTechNameSet()
 	if not techNameSet then
 		log("_technologyHelper returned empty techNameSet")
+		chainCallback()
 		return
 	end
 
@@ -1694,18 +1659,21 @@ function researchTech(color, cardName, chainCallback)
 		broadcastToAll('Research Technology: missing deckname ' .. deckName, color)
 		broadcastToAll("If you have researched all your available technologies: Congratulations to you " .. color .."!", color)
 		broadcastToAll("If not, please name your deck of remaining technology cards 'Technology Cards' and leave them in your zone.", color)
+		chainCallback()
 		return
 	end
 
 	local factionSheet = getObjectFromGUID(faction.factionSheetGuid)
 	if not factionSheet then
 		broadcastToAll('Research Technology: missing ' .. color .. ' Faction Sheet', 'Red')
+		chainCallback()
 		return
 	end
 
 	local guid = _getEntryGuid(techDeck, cardName) or _getEntryGuid(techDeck, cardName .. ' Ω')
 	if not guid then
 		_safeBroadcastToColor('Research Technology: ' .. cardName .. " not found in " .. techDeck.getName() .. " deck", color, "Red")
+		chainCallback()
 		return
 	end
 

--- a/Objects/StrategyCardAutomator.ttslua
+++ b/Objects/StrategyCardAutomator.ttslua
@@ -1657,12 +1657,14 @@ function researchTech(color, cardName, chainCallback)
 	local guidToPosTechOnTable = {}
 	local techType = _technologyHelper.getTechType(cardName)
 	if not techType then
-		error('_technologyHelper did not find "' .. cardName .. '"')
+		log('_technologyHelper did not find "' .. cardName .. '"')
+		return
 	end
 
 	local techNameSet = _technologyHelper.getTechNameSet()
 	if not techNameSet then
-		error("_technologyHelper returned empty techNameSet")
+		log("_technologyHelper returned empty techNameSet")
+		return
 	end
 
 	for _,object in ipairs(getAllObjects()) do


### PR DESCRIPTION
researchTech had premature returns when catching errors. This would break the techQueue, as subsequent queueResearchTech() calls only added to the techQueue, but the callback chain was broken by the error.
Each return in researchTech is now preceded by a chainCallback() to prevent.

All other changes highlighted by git are just changes in indentation.